### PR TITLE
add alpine-based fio image with runner

### DIFF
--- a/fio/alpine/Dockerfile.alpine
+++ b/fio/alpine/Dockerfile.alpine
@@ -1,0 +1,5 @@
+FROM alpine:latest
+RUN apk add nmap-ncat fio
+COPY docker-entrypoint.sh /
+
+CMD ["/docker-entrypoint.sh"]

--- a/fio/alpine/docker-entrypoint.sh
+++ b/fio/alpine/docker-entrypoint.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env sh
+set -e
+
+if [ -z $DBENCH_MOUNTPOINT ]; then
+    DBENCH_MOUNTPOINT=/tmp
+fi
+
+if [ -z $FIO_SIZE ]; then
+    FIO_SIZE=2G
+fi
+
+if [ -z $FIO_OFFSET_INCREMENT ]; then
+    FIO_OFFSET_INCREMENT=500M
+fi
+
+if [ -z $FIO_DIRECT ]; then
+    FIO_DIRECT=1
+fi
+
+if [ -z $FIO_NUMJOBS ]; then
+    FIO_NUMJOBS=1
+fi
+
+if [ -z $FIO_IODEPTH ]; then 
+    FIO_IODEPTH=64
+fi
+
+if [ -z $FIO_IOENGINE ]; then 
+    FIO_IOENGINE=libaio
+fi
+
+if [ -z $OPTIONS ]; then 
+    OPTIONS=''
+fi
+
+
+echo Working dir: $DBENCH_MOUNTPOINT
+echo
+
+if [ "$1" = 'fio' ]; then
+
+    echo Testing Read IOPS...
+    READ_IOPS=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=read_iops --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=$FIO_IODEPTH --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s $OPTIONS)
+    echo "$READ_IOPS"
+    READ_IOPS_VAL=$(echo "$READ_IOPS"|grep -E 'read ?:'|grep -Eoi 'IOPS=[0-9k.]+'|cut -d'=' -f2)
+    echo
+    echo
+
+    echo Testing Write IOPS...
+    WRITE_IOPS=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=write_iops --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=$FIO_IODEPTH --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s $OPTIONS)
+    echo "$WRITE_IOPS"
+    WRITE_IOPS_VAL=$(echo "$WRITE_IOPS"|grep -E 'write:'|grep -Eoi 'IOPS=[0-9k.]+'|cut -d'=' -f2)
+    echo
+    echo
+
+    echo Testing Read Bandwidth...
+    READ_BW=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=read_bw --filename=$DBENCH_MOUNTPOINT/fiotest --bs=128K --iodepth=$FIO_IODEPTH --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s $OPTIONS)
+    echo "$READ_BW"
+    READ_BW_VAL=$(echo "$READ_BW"|grep -E 'read ?:'|grep -Eoi 'BW=[0-9GMKiBs/.]+'|cut -d'=' -f2)
+    echo
+    echo
+
+    echo Testing Write Bandwidth...
+    WRITE_BW=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=write_bw --filename=$DBENCH_MOUNTPOINT/fiotest --bs=128K --iodepth=$FIO_IODEPTH --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s $OPTIONS)
+    echo "$WRITE_BW"
+    WRITE_BW_VAL=$(echo "$WRITE_BW"|grep -E 'write:'|grep -Eoi 'BW=[0-9GMKiBs/.]+'|cut -d'=' -f2)
+    echo
+    echo
+
+    if [ "$DBENCH_QUICK" == "" ] || [ "$DBENCH_QUICK" == "no" ]; then
+        echo Testing Read Latency...
+        READ_LATENCY=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --name=read_latency --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s $OPTIONS)
+        echo "$READ_LATENCY"
+        READ_LATENCY_VAL=$(echo "$READ_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[0-9.]+'|cut -d'=' -f2)
+        echo
+        echo
+
+        echo Testing Write Latency...
+        WRITE_LATENCY=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --name=write_latency --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s $OPTIONS)
+        echo "$WRITE_LATENCY"
+        WRITE_LATENCY_VAL=$(echo "$WRITE_LATENCY"|grep ' lat.*avg'|grep -Eoi 'avg=[0-9.]+'|cut -d'=' -f2)
+        echo
+        echo
+
+        echo Testing Read Sequential Speed...
+        READ_SEQ=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=read_seq --filename=$DBENCH_MOUNTPOINT/fiotest --bs=1M --iodepth=16 --size=$FIO_SIZE --readwrite=read --time_based --ramp_time=2s --runtime=15s --thread --offset_increment=$FIO_OFFSET_INCREMENT $OPTIONS)
+        echo "$READ_SEQ"
+        READ_SEQ_VAL=$(echo "$READ_SEQ"|grep -E 'READ:'|grep -Eoi '(aggrb|bw)=[0-9GMKiBs/.]+'|cut -d'=' -f2)
+        echo
+        echo
+
+        echo Testing Write Sequential Speed...
+        WRITE_SEQ=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=write_seq --filename=$DBENCH_MOUNTPOINT/fiotest --bs=1M --iodepth=16 --size=$FIO_SIZE --readwrite=write --time_based --ramp_time=2s --runtime=15s --thread --numjobs=4 --offset_increment=$FIO_OFFSET_INCREMENT $OPTIONS) 
+        echo "$WRITE_SEQ"
+        WRITE_SEQ_VAL=$(echo "$WRITE_SEQ"|grep -E 'WRITE:'|grep -Eoi '(aggrb|bw)=[0-9GMKiBs/.]+'|cut -d'=' -f2)
+        echo
+        echo
+
+        echo Testing Read/Write Mixed...
+        RW_MIX=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=rw_mix --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4k --iodepth=$FIO_IODEPTH --size=$FIO_SIZE --readwrite=randrw --rwmixread=75 --time_based --ramp_time=2s --runtime=15s $OPTIONS)
+        echo "$RW_MIX"
+        RW_MIX_R_IOPS=$(echo "$RW_MIX"|grep -E 'read ?:'|grep -Eoi 'IOPS=[0-9k.]+'|cut -d'=' -f2)
+        RW_MIX_W_IOPS=$(echo "$RW_MIX"|grep -E 'write:'|grep -Eoi 'IOPS=[0-9k.]+'|cut -d'=' -f2)
+        echo
+        echo
+    fi
+
+    echo All tests complete.
+    echo
+    echo ==================
+    echo = Dbench Summary =
+    echo ==================
+    echo "Random Read/Write IOPS: $READ_IOPS_VAL/$WRITE_IOPS_VAL. BW: $READ_BW_VAL / $WRITE_BW_VAL"
+    if [ -z $DBENCH_QUICK ] || [ "$DBENCH_QUICK" == "no" ]; then
+        echo "Average Latency (usec) Read/Write: $READ_LATENCY_VAL/$WRITE_LATENCY_VAL"
+        echo "Sequential Read/Write: $READ_SEQ_VAL / $WRITE_SEQ_VAL"
+        echo "Mixed Random Read/Write IOPS: $RW_MIX_R_IOPS/$RW_MIX_W_IOPS"
+    fi
+
+    rm $DBENCH_MOUNTPOINT/fiotest
+    exit 0
+fi
+
+exec "$@"

--- a/fio/alpine/docker-entrypoint.sh
+++ b/fio/alpine/docker-entrypoint.sh
@@ -2,72 +2,69 @@
 set -e
 
 if [ -z $DBENCH_MOUNTPOINT ]; then
-    DBENCH_MOUNTPOINT=/tmp
+    DBENCH_MOUNTPOINT=/data
 fi
 
-if [ -z $FIO_SIZE ]; then
-    FIO_SIZE=2G
-fi
+if [ -z $DBENCH_TYPE ] || [ "$DBENCH_TYPE" == "quick" ] || [ "$DBENCH_TYPE" == "detailed" ]; then
 
-if [ -z $FIO_OFFSET_INCREMENT ]; then
-    FIO_OFFSET_INCREMENT=500M
-fi
+    if [ -z $FIO_SIZE ]; then
+        FIO_SIZE=2G
+    fi
 
-if [ -z $FIO_DIRECT ]; then
-    FIO_DIRECT=1
-fi
+    if [ -z $FIO_OFFSET_INCREMENT ]; then
+        FIO_OFFSET_INCREMENT=500M
+    fi
 
-if [ -z $FIO_NUMJOBS ]; then
-    FIO_NUMJOBS=1
-fi
+    if [ -z $FIO_DIRECT ]; then
+        FIO_DIRECT=1
+    fi
 
-if [ -z $FIO_IODEPTH ]; then 
-    FIO_IODEPTH=64
-fi
+    if [ -z $FIO_NUMJOBS ]; then
+        FIO_NUMJOBS=1
+    fi
 
-if [ -z $FIO_IOENGINE ]; then 
-    FIO_IOENGINE=libaio
-fi
+    if [ -z $FIO_IOENGINE ]; then 
+        FIO_IOENGINE=libaio
+    fi
 
-if [ -z $OPTIONS ]; then 
-    OPTIONS=''
-fi
+    if [ -z $OPTIONS ]; then 
+        OPTIONS=''
+    fi
 
 
-echo Working dir: $DBENCH_MOUNTPOINT
-echo
+    echo Working dir: $DBENCH_MOUNTPOINT
+    echo
 
-if [ "$1" = 'fio' ]; then
 
     echo Testing Read IOPS...
-    READ_IOPS=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=read_iops --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=$FIO_IODEPTH --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s $OPTIONS)
+    READ_IOPS=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=read_iops --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=64 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s $OPTIONS)
     echo "$READ_IOPS"
     READ_IOPS_VAL=$(echo "$READ_IOPS"|grep -E 'read ?:'|grep -Eoi 'IOPS=[0-9k.]+'|cut -d'=' -f2)
     echo
     echo
 
     echo Testing Write IOPS...
-    WRITE_IOPS=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=write_iops --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=$FIO_IODEPTH --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s $OPTIONS)
+    WRITE_IOPS=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=write_iops --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=64 --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s $OPTIONS)
     echo "$WRITE_IOPS"
     WRITE_IOPS_VAL=$(echo "$WRITE_IOPS"|grep -E 'write:'|grep -Eoi 'IOPS=[0-9k.]+'|cut -d'=' -f2)
     echo
     echo
 
     echo Testing Read Bandwidth...
-    READ_BW=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=read_bw --filename=$DBENCH_MOUNTPOINT/fiotest --bs=128K --iodepth=$FIO_IODEPTH --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s $OPTIONS)
+    READ_BW=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=read_bw --filename=$DBENCH_MOUNTPOINT/fiotest --bs=128K --iodepth=64 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s $OPTIONS)
     echo "$READ_BW"
     READ_BW_VAL=$(echo "$READ_BW"|grep -E 'read ?:'|grep -Eoi 'BW=[0-9GMKiBs/.]+'|cut -d'=' -f2)
     echo
     echo
 
     echo Testing Write Bandwidth...
-    WRITE_BW=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=write_bw --filename=$DBENCH_MOUNTPOINT/fiotest --bs=128K --iodepth=$FIO_IODEPTH --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s $OPTIONS)
+    WRITE_BW=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=write_bw --filename=$DBENCH_MOUNTPOINT/fiotest --bs=128K --iodepth=64 --size=$FIO_SIZE --readwrite=randwrite --time_based --ramp_time=2s --runtime=15s $OPTIONS)
     echo "$WRITE_BW"
     WRITE_BW_VAL=$(echo "$WRITE_BW"|grep -E 'write:'|grep -Eoi 'BW=[0-9GMKiBs/.]+'|cut -d'=' -f2)
     echo
     echo
 
-    if [ "$DBENCH_QUICK" == "" ] || [ "$DBENCH_QUICK" == "no" ]; then
+    if [ "$DBENCH_TYPE" == "" ] || [ "$DBENCH_TYPE" == "detailed" ]; then
         echo Testing Read Latency...
         READ_LATENCY=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --name=read_latency --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4K --iodepth=4 --size=$FIO_SIZE --readwrite=randread --time_based --ramp_time=2s --runtime=15s $OPTIONS)
         echo "$READ_LATENCY"
@@ -97,7 +94,7 @@ if [ "$1" = 'fio' ]; then
         echo
 
         echo Testing Read/Write Mixed...
-        RW_MIX=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=rw_mix --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4k --iodepth=$FIO_IODEPTH --size=$FIO_SIZE --readwrite=randrw --rwmixread=75 --time_based --ramp_time=2s --runtime=15s $OPTIONS)
+        RW_MIX=$(fio --numjobs=$FIO_NUMJOBS --randrepeat=0 --verify=0 --ioengine=$FIO_IOENGINE --direct=$FIO_DIRECT --gtod_reduce=1 --name=rw_mix --filename=$DBENCH_MOUNTPOINT/fiotest --bs=4k --iodepth=64 --size=$FIO_SIZE --readwrite=randrw --rwmixread=75 --time_based --ramp_time=2s --runtime=15s $OPTIONS)
         echo "$RW_MIX"
         RW_MIX_R_IOPS=$(echo "$RW_MIX"|grep -E 'read ?:'|grep -Eoi 'IOPS=[0-9k.]+'|cut -d'=' -f2)
         RW_MIX_W_IOPS=$(echo "$RW_MIX"|grep -E 'write:'|grep -Eoi 'IOPS=[0-9k.]+'|cut -d'=' -f2)
@@ -111,7 +108,7 @@ if [ "$1" = 'fio' ]; then
     echo = Dbench Summary =
     echo ==================
     echo "Random Read/Write IOPS: $READ_IOPS_VAL/$WRITE_IOPS_VAL. BW: $READ_BW_VAL / $WRITE_BW_VAL"
-    if [ -z $DBENCH_QUICK ] || [ "$DBENCH_QUICK" == "no" ]; then
+    if [ -z $DBENCH_TYPE ] || [ "$DBENCH_TYPE" == "detailed" ]; then
         echo "Average Latency (usec) Read/Write: $READ_LATENCY_VAL/$WRITE_LATENCY_VAL"
         echo "Sequential Read/Write: $READ_SEQ_VAL / $WRITE_SEQ_VAL"
         echo "Mixed Random Read/Write IOPS: $RW_MIX_R_IOPS/$RW_MIX_W_IOPS"
@@ -119,6 +116,15 @@ if [ "$1" = 'fio' ]; then
 
     rm $DBENCH_MOUNTPOINT/fiotest
     exit 0
-fi
+
+else 
+    
+    echo Testing Custom I/O Profile..
+
+    ## In custom jobs, parsing the simple o/p as with above runs may not be effective as the o/p keys change based on params.
+    ## Unmodified Json output will be provided for user consumption 
+    fio --filename=$DBENCH_MOUNTPOINT/fiotest --output-format=json $CUSTOM 
+    rm -f $DBENCH_MOUNTPOINT/*
+fi    
 
 exec "$@"


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Include an image with a smaller foot-print (alpine) and a fio runner based on the one used in `sotoaster/dbench` 
- Provide ENV to control coverage of the fio tests as `quick`, `detailed` & `custom` (single/one-off) run. 
- Outputs will be parsed for `quick` & `detailed` mode to provide a summary, an unparsed json output is provided for custom runs.

- Example of a job using this image: 

```yaml

# NOTE: For details of params to construct an fio job, refer to this link:
# https://fio.readthedocs.io/en/latest/fio_doc.html

---
apiVersion: batch/v1
kind: Job
metadata:
  generateName: dbench-
spec:
  template:
    spec:
      containers:
      - name: dbench
        image: openebs/perf-test:latest
        imagePullPolicy: IfNotPresent
        env:

          ## storage mount point on which testfiles are created

          - name: DBENCH_MOUNTPOINT
            value: /data

          ##########################################################
          # I/O PROFILE COVERAGE FOR SPECIFIC PERF CHARACTERISTICS #
          ##########################################################

          ## quick: {read, write} iops, {read, write} bw (all random)
          ## detailed: {quick}, {read, write} latency & mixed 75r:25w (all random), {read, write} bw (all sequential)  
          ## custom: a single user-defined job run with params specified in env 'CUSTOM'

          - name: DBENCH_TYPE
            value: detailed

          ####################################################
          # STANDARD TUNABLES FOR DBENCH_TYPE=QUICK/DETAILED #
          ####################################################

          ## active data size for the bench test

          - name: FIO_SIZE
            value: 2G

          ## use un-buffered i/o (usually O_DIRECT)

          - name: FIO_DIRECT
            value: '1'

          ## no of independent threads doing the same i/o

          - name: FIO_NUMJOBS
            value: '1'

          ## space b/w starting offsets on a file in case of parallel file i/o

          - name: FIO_OFFSET_INCREMENT
            value: 250M

          ## nature of i/o to file. commonly supported: libaio, sync, 

          - name: FIO_IOENGINE
            value: libaio

          ## additional runtime options which will be appended to the above params
          ## ensure options used are not mutually exclusive w/ above params
          ## ex: '--group_reporting=1, stonewall, --ramptime=<val> etc..,

          - name: OPTIONS
            value: ''

          ####################################################
          # CUSTOM JOB SPEC FOR DBENCH_TYPE=CUSTOM           #
          ####################################################

          ## this will execute a single job run with the params specified 
          ## ex: '--bs=16k --iodepth=64 --ioengine=sync --size=500M --name=custom --readwrite=randrw --rwmixread=80 --random_distribution=pareto' 

          - name: CUSTOM
            value: ''

        volumeMounts:
        - name: dbench-pv
          mountPath: /data
      restartPolicy: Never
      volumes:
      - name: dbench-pv
        emptyDir: {}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
- The script is a simple executor of fio profiles & doesn't include validations for values provided as fio params. The fio tool itself is seen to call out improper values and display a help in return. 