### PR TITLE
(feat)image: create a persistent volume metrics monitor image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ before_install:
   - sudo apt-get install -y curl
 jobs:
   include:
-    - stage: build docker images
-      name: build docker image vdbench
-      script:
-      - make vdbench
+    #- stage: build docker images
+    #  name: build docker image vdbench
+    #  script:
+    #  - make vdbench
     - stage: build docker images
       name: build docker image forkbomb
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,10 @@ jobs:
       name: build docker image linux-utils
       script:
       - make linux-utils
+    - stage: build docker images
+      name: build docker image pv-monitor
+      script:
+      - make pv-monitor
 notifications:
   email:
     recipients:

--- a/Makefile
+++ b/Makefile
@@ -264,11 +264,21 @@ _push_tests_elasticsearch_stress_image:
 
 elasticsearch-stress: deps _build_tests_elasticsearch_stress_image _push_tests_elasticsearch_stress_image
 
+_build_pv_monitor_image:
+	@echo "INFO: Building container image for pv-metrics-monitor"
+	cd pv-monitor && docker build -t openebs/pv-monitor .
+
+_push_pv_monitor_image:
+	@echo "INFO: Publish container (openebs/pv-metrics-monitor)"
+	cd pv-monitor/buildscripts && ./push
+
+pv-monitor: deps _build_pv_monitor_image _push_pv_monitor_image
+
 _build_gitlab_runner_infra_image:
 	@echo "INFO: Building container image for gitlab-runner-infra"
 	cd gitlab-runner/buildscripts && ./build.sh
 gitlab-runner: deps _build_gitlab_runner_infra_image
-build: deps vdbench fio iometer mysql-client tpcc-client mongo-client jenkins-client postgres-client custom-client libiscsi logger gitlab-runner
+build: deps vdbench fio iometer mysql-client tpcc-client mongo-client jenkins-client postgres-client custom-client libiscsi logger gitlab-runner pv-monitor
 
 
 

--- a/pv-monitor/Dockerfile
+++ b/pv-monitor/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+LABEL maintainer="OpenEBS"
+RUN apt-get update || true \
+    && apt-get install -y curl
+ENV KUBE_LATEST_VERSION="v1.15.3"
+RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+ && chmod +x /usr/local/bin/kubectl
+COPY textfile_collector.sh /

--- a/pv-monitor/buildscripts/push
+++ b/pv-monitor/buildscripts/push
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+IMAGEID=$( docker images -q openebs/pv-monitor )
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
+then 
+  docker login -u "${DNAME}" -p "${DPASS}"; 
+  #Push to docker hub repository with latest tag
+  docker tag ${IMAGEID} openebs/pv-monitor:latest
+  docker push openebs/pv-monitor:latest; 
+else
+  echo "No docker credentials provided. Skip uploading openebs/pv-monitor:latest to docker hub"; 
+fi;

--- a/pv-monitor/textfile_collector.sh
+++ b/pv-monitor/textfile_collector.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+FILEPATH=${TEXTFILE_PATH:=/shared_vol}
+INTERVAL=${COLLECT_INTERVAL:=10}
+
+## calculate_pv_capacity obtains the size of a PV in bytes
+function calculate_pv_capacity(){
+
+  unit=$(echo "${size_in_spec: -1}")
+
+  case "${unit}" in 
+  
+  g|gi) echo $((1024*1024*1024*$(echo $1 | cut -d "${unit}" -f 1)))
+     ;;
+  m|mi) echo $((1024*1024*$(echo $1 | cut -d "${unit}" -f 1)))
+     ;;
+  k|ki) echo $((1024*$(echo $1 | cut -d "${unit}" -f 1)))
+     ;;
+  b|bi) echo $1 | cut -d "${unit}" -f 1
+     ;;
+  *) echo 0
+     ;;
+  esac
+}
+
+## collect_pv_capacity_metrics collects the PV capacity metrics
+function collect_pv_capacity_metrics(){
+ 
+  ##TODO: We clear the file and then proceed to derive the metrics in the for loop below.
+  ## If, the block below takes time, it may cause a few seconds of "no-metrics". 
+  ## This needs to be optimized. Preferable approach is to replace values v/s recreating the file.  
+  > ${FILEPATH}/pv_size.prom
+
+  for i in ${pv_list[@]}
+  do
+    size_in_spec=$(kubectl get pv ${i} -o custom-columns=:spec.capacity.storage --no-headers | tr '[:upper:]' '[:lower:]')
+    size_in_bytes=$(calculate_pv_capacity ${size_in_spec};)
+    echo "pv_capacity_bytes{persistentvolume=\"${i}\"} ${size_in_bytes}" >> ${FILEPATH}/pv_size.prom
+  done
+}
+
+## collect_pv_utilization_metrics collects the PV utilization metrics
+function collect_pv_utilization_metrics(){
+
+  ##TODO: We clear the file and then proceed to derive the metrics in the for loop below.
+  ## If, the block below takes time, it may cause a few seconds of "no-metrics". 
+  ## This needs to be optimized. Preferable approach is to replace values v/s recreating the file.  
+  > ${FILEPATH}/pv_used.prom
+
+  declare -a pv_mount_list=()
+
+  for i in ${pv_list[@]}
+  do
+    pv_mount_list+=($(df -h | grep ${i} | awk '{print $NF}'))
+  done
+
+  echo "mount list: ${pv_mount_list[@]}"
+  for i in ${pv_mount_list[@]}
+  do
+    ## Get mount point utilization in bytes
+    mount_data=$(du -sb ${i})
+    utilization=$(echo ${mount_data}| cut -d " " -f 1)
+    pv_name=$(basename $(echo ${mount_data} | cut -d " " -f 2))
+    echo "pv_utilization_bytes{persistentvolume=\"${pv_name}\"} ${utilization}" >> ${FILEPATH}/pv_used.prom
+  done
+}
+
+while true
+do
+  declare -a pv_list=()
+
+  ## Select only those PVs that are bound. Several stale PVs can exist.
+  for i in $(kubectl get pv -o jsonpath='{.items[?(@.status.phase=="Bound")].metadata.name}')
+  do
+    pv_list+=(${i})
+  done
+
+  echo "pv_list: ${pv_list[@]}"
+  collect_pv_capacity_metrics;
+  collect_pv_utilization_metrics;
+  sleep ${INTERVAL}
+done


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

 This PR introduces an a persistent volume capacity monitor container for Kubernetes. It is typically expected to be deployed as a sidecar to the node-exporter on the cluster. The container uses the textfile collector approach to gather the PV metrics, while allowing node-exporter to expose them. The flow/working & usage  details of the collector is provided below:  

- The pod running this container is expected to use a service account with cluster-level scope. (In case of the openebs node-exporter: openebs-maya-operator)

- The pv-monitor sidecar is expected to have similar volume mounts as the node-exporter, including the host root fs configured with a HostToContainer propagation to detect new PV mounts on the host.

- A list of active/Bound PVs is obtained, which capacity/size & current utilization are gathered. The utilization is obtained via the `du` command on the PVs mounted at the `/var/lib/kubelet/pods/<>` paths

- A set of of textfiles are updated into a specified shared path (achieved by a shared temp volume such as emptyDir{}), via a polling mechanism, with configurable intervals in a format desired by the node-exporter:

```
pv_capacity_bytes{persistentvolume="pvc-8b6eb31b-cecd-11e9-b8b2-42010a800039"} 5368709120
pv_capacity_bytes{persistentvolume="pvc-577bc663-cf18-11e9-b8b2-42010a800039"} 5368709120
```
```
pv_utilization_bytes{persistentvolume="pvc-8b6eb31b-cecd-11e9-b8b2-42010a800039"} 218944
pv_utilization_bytes{persistentvolume="pvc-577bc663-cf18-11e9-b8b2-42010a800039"} 218824
```
- The node-exporter is configured to monitor the textfile collector directories. 

```
--collector.textfile.directory=/shared_vol
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- Subsequent improvements can include ability to replace values on the textfiles instead of recreate, using a lighter base image & making the scripts more robust for failure conditions (change to python/go) 

- Sample dashboard showing utilization percentages with the prom query: `((pv_utilization_bytes) *100 / pv_capacity_bytes)` 

![image](https://user-images.githubusercontent.com/21166217/64344996-25de7900-d00d-11e9-898b-f76119ad9986.png)
