### PR TITLE
MYSQL Client LoadGen refactor

### DIFF
--- a/mysql-client/Dockerfile
+++ b/mysql-client/Dockerfile
@@ -2,6 +2,13 @@ FROM alpine
 
 LABEL maintainer="OpenEBS"
 
+RUN apk add --no-cache mysql-client && apk add --no-cache jq && apk add --no-cache curl && apk add --no-cache bash \
+        && apk add --no-cache  --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing moreutils \
+        && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community bareos
+
+RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubectl && \
+  chmod +x /usr/bin/kubectl
+
 RUN apk add --no-cache mysql-client && apk add --no-cache jq && apk add --no-cache bash \
         && apk add --no-cache  --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing moreutils \
         && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community bareos

--- a/mysql-client/Dockerfile
+++ b/mysql-client/Dockerfile
@@ -9,8 +9,4 @@ RUN apk add --no-cache mysql-client && apk add --no-cache jq && apk add --no-cac
 RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubectl && \
   chmod +x /usr/bin/kubectl
 
-RUN apk add --no-cache mysql-client && apk add --no-cache jq && apk add --no-cache bash \
-        && apk add --no-cache  --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing moreutils \
-        && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community bareos
-
 COPY MySQLLoadGenerate.sh mysql-liveness-check.sh /

--- a/mysql-client/MySQLLoadGenerate.sh
+++ b/mysql-client/MySQLLoadGenerate.sh
@@ -1,26 +1,185 @@
 #! /bin/sh
 
+#############################################################
+# This script will create an empty database and fill
+# it with data continuously till the pod is alive.
+#############################################################
+
+
+#######################
+##   FUCNTION DEF    ##       
+#######################
+
+function show_help(){
+    cat << EOF
+Usage : $(basename "$0") -h help
+        $(basename "$0") -k <pod label key>
+        $(basename "$0") -v <pod label value>
+        $(basename "$0") -u <mysql username>
+        $(basename "$0") -p <mysql password>
+        $(basename "$0") -n <pod namespace>
+
+-h      Display this help and exit
+-k      Label key of pod, ex: app
+-v      Label value of pod, ex: percona
+-u      Username of MYSQL, ex: root
+-p      Password of MYSQL, ex: abcd1234
+-n      Namespace of Percona application pod, ex: percona
+
+Examples: 
+
+sh MySQLLoadGenerate.sh -k app -v percona -u root -p abcd1234 -n percona
+
+EOF
+}
+
+# Checks whether the Percona application pod is in "Running" state
+function wait_for_pod(){
+
+    pTimeOut=$1
+
+    c=1
+    while [[ $c -lt $pTimeOut ]]; do
+        # Get the pod in the specified namespace
+        pName=$(kubectl get pods --no-headers -n $pod_ns -l $lk=$lv -o custom-columns=:metadata.name)
+
+        # Check if the pod is in running state
+        if [[ $(kubectl get pod $pName -n $pod_ns -o go-template --template "{{.status.phase}}") == "Running" 2>/dev/null ]]; then
+            # Get pod IP
+            pod_ip=$(kubectl get pod $pName -n $pod_ns -o go-template --template "{{.status.podIP}}")
+            return
+        else
+            if [[ $c -eq 1 ]]; then
+                echo -n "Waiting for application pod to be in running state"
+            fi
+            if [[ $(( c%5 )) -eq 0 ]]; then
+                echo -n "."
+            fi
+        fi
+        c=$(( c+1 ))
+        sleep 1
+    done
+    echo -e "\n\e[91mUnable to bring up percona pod, exiting..\e[0m"
+    exit 1
+}
+
 MySQLDump()
 {
-while true
-do
- mysql -uroot -pk8sDem0 -h $pod_ip -e "INSERT INTO Hardware select * FROM Hardware;" Inventory
- sleep 2
-done
+    echo -e "\n\e[96mLoadGen started!!\e[0m\n"
+    while true
+    do
+        wait_for_pod $podTimeOut;
+        mysql -u$sql_un -p$sql_pw -h $pod_ip -e "INSERT INTO Hardware select * FROM Hardware;" Inventory
+        # Use a sync or sudo sync command in future
+        # sync/sudo sync;
+        sleep 2
+    done
 }
 
 PrepareMySQL()
 {
-mysql -uroot -pk8sDem0 -h $pod_ip -e "CREATE DATABASE Inventory;"
+    if mysql -u$sql_un -p$sql_pw -h $pod_ip -e "USE Inventory" 2>/dev/null; then
+        mysql -u$sql_un -p$sql_pw -h $pod_ip -e "DROP DATABASE Inventory;"
+        echo -e "Deleted existing DataBase: \e[93mInventory\e[0m"
+    fi
 
-mysql -uroot -pk8sDem0 -h $pod_ip -e \
-"CREATE TABLE Hardware (Name VARCHAR(20),HWtype VARCHAR(20),Model VARCHAR(20));" Inventory 
+    mysql -u$sql_un -p$sql_pw -h $pod_ip -e "CREATE DATABASE Inventory;"
+    # mysql -u$sql_un -p$sql_pw -h $pod_ip -e "CREATE DATABASE IF NOT EXISTS Inventory;"
+    echo -e "Created new DataBase: \e[93mInventory\e[0m"
 
-mysql -uroot -pk8sDem0 -h $pod_ip -e \
-"INSERT INTO Hardware (Name,HWtype,Model) VALUES ('TestBox','Server','DellR820');" Inventory
+    mysql -u$sql_un -p$sql_pw -h $pod_ip -e \
+    "CREATE TABLE Hardware (SNo VARCHAR(15),Name VARCHAR(15));" Inventory
+    echo -e "Created table in DataBase: \e[93mHardware\e[0m"
+
+    mysql -u$sql_un -p$sql_pw -h $pod_ip -e \
+    "INSERT INTO Hardware (SNo,Name) VALUES ('1','John');" Inventory
+    echo "Added sample values in DataBase"
 }
 
-pod_ip=$1
+#######################
+##   TEST VARIABLES  ##
+#######################
+
+# Time to wait for Percona pod to instantiate
+podTimeOut=120
+# Garbage IP
+pod_ip=0.0.0.0
+# Garbage Key
+lk=app
+# Garbage Value
+lv=percona
+# Garbage username
+sql_un=root
+# Garbage password
+sql_pw=abcd1234
+# Garbage namespace
+pod_ns=percona
+
+#######################
+## VERIFY ARGUMENTS  ##
+#######################
+
+if [[ $# -eq 0 ]]; then
+    show_help
+    exit 1
+fi
+
+# Obtain the input arguments
+while getopts ":h:k:v:u:p:n:" option
+do
+    case $option in
+
+        h)  # Display help/usage
+            show_help
+            exit
+            ;;
+
+        k)  # Ensure the label key is specified
+            # Set the lk variable
+            lk=${OPTARG}
+            ;;
+
+        v)  # Ensure the label value is specified
+            # Set the lv variable
+            lv=${OPTARG}
+            ;;
+
+        u)  # Ensure the MYSQL user name is specified
+            # Set the sql_ns variable
+            sql_un=${OPTARG}
+            ;;
+
+        p)  # Ensure the MYSQL password is specified
+            # Set the sql_pw variable
+            sql_pw=${OPTARG}
+            ;;
+
+        n)  # Ensure Pod namespace is specified
+            # Set the pod_ns variable
+            pod_ns=${OPTARG}
+            ;;
+
+        *)  # Undesired arguments
+            echo "Incorrect arguments provided, please check usage"
+            show_help
+            exit 1
+            ;;
+    esac
+done 
+
+########################
+##   RUN TEST STEPS   ##
+########################
+
+echo -e "\nRunning script MySQLLoadGenerator.sh\n"
+
+# Check if Percona application pod is running
+wait_for_pod $podTimeOut;
+
+# Create empty database
 PrepareMySQL;
+
+# Start populating the database
 MySQLDump; 
 
+echo -e "\e[32mLoadGen run finished!!\e[0m"

--- a/mysql-client/README.md
+++ b/mysql-client/README.md
@@ -3,7 +3,7 @@
 This image provides a couple of simple bash scripts that can be used alongside percona/mysql deployments to test their health & functionality
 
 **Loadgen (MySQLLoadGenerate.sh)**: This script creates sample database with some initial data and inserts tables in an exponential manner 
-(`INSERT INTO <table> select * FROM <table>` ).It takes the IP address of the mysql service as the argument & can be used in sample loadgen jobs.
+(`INSERT INTO <table> select * FROM <table>` ).It takes the label of the pod, thee databse credentials of the mysql service and the namespace of the pod as the argument & can be used in sample loadgen jobs.
 
 **Liveness (mysql-liveness-check.sh)**: This script checks the status of the mysql service periodically with pre-defined interval & timeouts.
 It takes a JSON file with database credentials as argument & can be used in external liveness jobs such as the one defined [here](mysql-liveness-check.yaml), with the credentials passed as a configmap, as shown [here](db-cred.cnf)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Refactoring of MySQLLoadGenerator.sh
The script will detect the application pod in the given namespace and auto-detect its IP.
Then will generate exponential workload on the application.
In case the pod is unavailable, it will retry connection for 120 seconds then exit.

**Commaand to Execute this script:**
`sh MySQLLoadGenerate.sh -k label-key -v label-value -u mysql-user -p mysql-password -n app-namespace`

**Logs:**
```
Running script MySQLLoadGenerator.sh

Deleted existing DataBase: Inventory
Created new DataBase: Inventory
Created table in DataBase: Hardware
Added sample values in DataBase

LoadGen started!!
```
Signed-off-by: sakshamkatiyar saksham.katiyar@mayadata.io