### PR TITLE
fix(linux-utils): bump alpine base image to 3.10.3

### DIFF
--- a/linux-utils/Dockerfile
+++ b/linux-utils/Dockerfile
@@ -1,2 +1,2 @@
-FROM alpine:3.9
+FROM alpine:3.10.3
 RUN apk add --no-cache util-linux

--- a/linux-utils/buildscripts/push
+++ b/linux-utils/buildscripts/push
@@ -7,10 +7,10 @@ if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
 then
   docker login -u "${DNAME}" -p "${DPASS}";
   #Push to docker hub repository with alpine version tag
-  docker tag ${IMAGEID} openebs/linux-utils:3.9
-  docker push openebs/linux-utils:3.9;
+  docker tag ${IMAGEID} openebs/linux-utils:3.10
+  docker push openebs/linux-utils:3.10;
 else
-  echo "No docker credentials provided. Skip uploading openebs/linux-utils:3.9 to docker hub";
+  echo "No docker credentials provided. Skip uploading openebs/linux-utils:3.10 to docker hub";
 fi;
 
 if [ ! -z "${QNAME}" ] && [ ! -z "${QPASS}" ];
@@ -19,8 +19,8 @@ then
   docker login -u "${QNAME}" -p "${QPASS}" quay.io;
 
 	#Push to docker hub repository with alpine version tag
-  docker tag openebs/linux-utils:3.9 quay.io/openebs/linux-utils:3.9
-  docker push quay.io/openebs/linux-utils:3.9;
+  docker tag openebs/linux-utils:3.10 quay.io/openebs/linux-utils:3.10
+  docker push quay.io/openebs/linux-utils:3.10;
 else
-  echo "No docker credentials provided. Skip uploading quay.io/openebs/linux-utils:3.9 to docker hub";
+  echo "No docker credentials provided. Skip uploading quay.io/openebs/linux-utils:3.10 to docker hub";
 fi;


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Bump alpine base image to 1.10.3 to fix some vulnerabilities.