### PR TITLE
Add CPU resource chaos job using DIND container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,10 @@ jobs:
       name: build docker image kafka-client
       script:
       - make kafka-client
+    - stage: build docker images
+      name: build docker image app-cpu-stress
+      script:
+      - make app-cpu-stress
 notifications:
   email:
     recipients:

--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,17 @@ _push_tests_kafka_client_image:
 
 kafka-client: deps _build_tests_kafka_client_image _push_tests_kafka_client_image
 
+_build_tests_app_cpu_stress_image:
+	@echo "INFO: Building container image for performing app-cpu-stress"
+	cd app-cpu-stress && docker build -t litmuschaos/app-cpu-stress .
+
+_push_tests_app_cpu_stress_image:
+	@echo "INFO: Publish container (litmuschaos/app-cpu-stress)"
+	cd app-cpu-stress/buildscripts && ./push
+
+app-cpu-stress: deps _build_tests_app_cpu_stress_image _push_tests_app_cpu_stress_image 
+
+# busybox: deps _build_tests_busybox_client_image _push_tests_busybox_client_image
 
 # This is done to avoid conflict with a file of same name as the targets
 # mentioned in this makefile

--- a/app-cpu-stress/Dockerfile
+++ b/app-cpu-stress/Dockerfile
@@ -1,0 +1,2 @@
+FROM docker:dind
+COPY cpu-hog.sh /

--- a/app-cpu-stress/app-cpu-stress.yml
+++ b/app-cpu-stress/app-cpu-stress.yml
@@ -1,0 +1,41 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: app-cpu-stress
+spec:
+  template:
+    metadata:
+      labels:
+        app: app-cpu-stress
+    spec:
+      nodeSelector:
+        ## mandatory: provide name of host where target container resides
+        kubernetes.io/hostname: ""
+      restartPolicy: Never
+      containers:
+      - image: litmuschaos/app-cpu-stress:ci
+        imagePullPolicy: Always
+        name: app-cpu-stress
+        command: 
+        - /bin/sh
+        args:
+        - ./cpu-hog.sh 
+        env:
+            ## mandatory: provide id of docker container
+          - name: CONTAINER_ID
+            value: ""
+            ## optional: provide duration of cpu chaos 
+            ## default: 60 (in sec)
+          - name: DURATION
+            value: ""
+            ## optional: provide number of cpu cores to be consumed in container
+            ## default: 1
+          - name: CORES
+            value: ""
+        volumeMounts:
+          - name: dockersocket
+            mountPath: /var/run/docker.sock
+      volumes:
+        - hostPath:
+            path: /var/run/docker.sock
+          name: dockersocket

--- a/app-cpu-stress/buildscripts/push
+++ b/app-cpu-stress/buildscripts/push
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+IMAGEID=$( docker images -q litmuschaos/app-cpu-stress:latest)
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
+then 
+  docker login -u "${DNAME}" -p "${DPASS}"; 
+  #Push to docker hub repository with latest tag
+  docker push litmuschaos/app-cpu-stress; 
+else
+  echo "No docker credentials provided. Skip uploading litmuschaos/app-cpu-stress:latest to docker hub"; 
+fi;
+

--- a/app-cpu-stress/cpu-hog.sh
+++ b/app-cpu-stress/cpu-hog.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+## mandatory arg
+container_id=${CONTAINER_ID}
+
+## optional args
+core_count=${CORES:=1}
+duration=${DURATION:=60}
+
+## initialize chaos command
+chaos_cmd="md5sum /dev/zero"
+
+if [ ! -z "${CONTAINER_ID}" ]; then 
+
+        echo "starting cpu consumption for ${core_count} cores"
+        i=0
+        while [ ${i} -lt ${core_count} ]; do
+                echo "consuming cpu core ${i}"
+                docker exec ${container_id} ${chaos_cmd} &
+                i=$((i+1))
+        done
+
+        echo "let chaos prevail for ${duration} seconds.."
+        sleep ${duration}
+
+        echo "stopping cpu chaos"
+        chaos_pids=$(docker exec ${container_id} ps afx | grep "${chaos_cmd}" | awk '{print$1}') 
+        for i in $chaos_pids; do docker exec ${container_id} kill -9 $i; done 
+else
+        echo "Please provide mandatory ENV variables CONTAINER_ID & DURATION (in seconds)"
+        exit 1 
+fi

--- a/kafka-client/consumer.sh
+++ b/kafka-client/consumer.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-kafka-console-consumer --bootstrap-server ${KAFKA_SERVICE}:${KAFKA_PORT} --topic ${TOPIC_NAME} --timeout-ms ${KAFKA_CONSUMER_TIMEOUT} | ts '[%Y-%m-%d %H:%M:%S]' 
+if [ ! -z "${KAFKA_OPTS}" ]; then
+  kafka-console-consumer --bootstrap-server ${KAFKA_SERVICE}:${KAFKA_PORT} --topic ${TOPIC_NAME} --timeout-ms ${KAFKA_CONSUMER_TIMEOUT} --consumer.config /opt/client.properties | ts '[%Y-%m-%d %H:%M:%S]' 
+else
+  kafka-console-consumer --bootstrap-server ${KAFKA_SERVICE}:${KAFKA_PORT} --topic ${TOPIC_NAME} --timeout-ms ${KAFKA_CONSUMER_TIMEOUT} | ts '[%Y-%m-%d %H:%M:%S]'
+fi
+
+
 
 
 

--- a/kafka-client/producer.sh
+++ b/kafka-client/producer.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 i=0
-while true; do 
-  echo "message_index ${i} produced @ $(date -u)" | kafka-console-producer --broker-list ${KAFKA_SERVICE}:${KAFKA_PORT} --topic ${TOPIC_NAME}
+while true; do
+  if [ ! -z "${KAFKA_OPTS}" ]; then 	
+    echo "message_index ${i} produced @ $(date -u)" | kafka-console-producer --broker-list ${KAFKA_SERVICE}:${KAFKA_PORT} --topic ${TOPIC_NAME} --producer.config /opt/client.properties
+  else
+    echo "message_index ${i} produced @ $(date -u)" | kafka-console-producer --broker-list ${KAFKA_SERVICE}:${KAFKA_PORT} --topic ${TOPIC_NAME}
+  fi
+
   ((i++)) 
 done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Resource chaos isolated to app-level can be invoked using a docker-in-docker container that mounts the docker socket (/var/run/docker.sock) file 

- The number of CPU cores, duration of chaos & Target Container ID are passed as environment variables to a CPU Stress Kubernetes job which is specified to run on a given node via a nodeSelector property. 

- The job deploys a DIND container that runs a shell script to asynchronously trigger multiple instances of the command `md5sum /dev/zero` depending on the number of CPU cores.

- After a period equalling the `DURATION`, the triggered processes are killed to stop the CPU chaos. 

**Notes** 

- While tools such as `stress-ng` are capable to achieving the same with greater options, it is necessary to inject the stress binary into the target container at run-time, which is not preferable (different distros of base images may need custom built stress-ng). Wheres the md5sum tool & special file - `/dev/zero` are available on most minimal base OS as well (alpine, busybox, debian etc.,) 

-   The command used to identify the running cpu chaos processes uses `ps afx` -- which is a safer bet due to the availability of the complete command in the `ps` output (as against just ps, ps aux, ps -ef etc.., which offer different level of command expansion in different base OS). The script also uses the complete command `md5sum /dev/zero` in order to distinguish it from other processes which may being using `md5sum` or `/dev/zero`, say. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #https://github.com/litmuschaos/litmus/issues/974

**Special notes for your reviewer**:
- The job will be used as a jinja template in the litmuschaos experiment & launched upon deriving the dependent parameters.  