### PR TITLE
Refactor dd-client to make it generic for k8s applications

### DIFF
--- a/dd-client/Dockerfile
+++ b/dd-client/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:16.04
+FROM alpine:latest
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        fio \
-    && apt-get clean
+RUN apk add -U curl bash
 
+RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kubectl && \
+  chmod +x /usr/bin/kubectl && \
+kubectl version --client
 
 COPY io_runner.sh /
 

--- a/dd-client/README.md
+++ b/dd-client/README.md
@@ -1,0 +1,13 @@
+# Generic DD-client 
+- Purpose:
+```
+To write data on volume mount point of Kubernetes applications.
+```
+- Compatibility:
+``` 
+This client is only compatible for application which have dd-utility installed.
+```
+Pre-requisites:
+```
+- Mandatory ENVs such as [BLOCK_SIZE, COUNT, NAMESPACE, MOUNT_POINT, APP_LABEL, RETRY_DURATION, RETRY_COUNT] should be present in job spec (dd-client.yml) before launching client 
+``` 

--- a/dd-client/dd_client.yml
+++ b/dd-client/dd_client.yml
@@ -1,0 +1,50 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: dd-client-
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      name: dd-client
+      namespace: litmus
+      labels:
+        app: dd-client
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+ 
+      containers:
+      - name: dd-client 
+        image: openebs/tests-dd-client
+        imagePullPolicy: Always
+        tty: true
+
+        env:
+
+          - name: BLOCK_SIZE
+            value: "4k"
+ 
+          - name: COUNT
+            value: "1024"
+
+            # Namespace in which Application is running
+          - name: NAMESPACE
+            value: ''
+         
+            # Application label
+          - name: APP_LABEL
+            value: '' 
+            
+          - name: MOUNT_POINT
+            value: ''
+
+          - name: RETRY_COUNT
+            value: '5'
+
+          - name: RETRY_DURATION
+            value: '5'
+
+        command: ["/bin/bash"]
+        args: ["-c", "./io_runner.sh; exit 0"]

--- a/dd-client/io_runner.sh
+++ b/dd-client/io_runner.sh
@@ -1,27 +1,42 @@
 #!/bin/bash
 
-#######################################################################################################################
-# Script Name   : io_runner.sh         									      		
-# Description   : Run dd profiles on the /datadir. 
-# Creation Data : 12/10/2018                                                                                          
-# Modifications : None											               		
-# Script Author : Sudarshan					      
-#######################################################################################################################
+get_env () {
+   tmpVar=$(echo $1)
+   if [ -z "$tmpVar" ]; then
+      echo "Unable to get all ENVs";
+      echo "Kindly make sure to provide [BLOCK_SIZE, COUNT, NAMESPACE, MOUNT_POINT, APP_LABEL, RETRY_DURATION, RETRY_COUNT]"
+      exit 1;
+   fi
+   echo "$tmpVar"
+}
 
-TEST_SIZE="512k"
-TEST_COUNT="1000"
+blockSize=$(get_env $BLOCK_SIZE;)    
+count=$(get_env $COUNT;)
+namespace=$(get_env $NAMESPACE;)
+mountPoint=$(get_env $MOUNT_POINT;)
+app_label=$(get_env $APP_LABEL;)
+retry_duration=$(get_env $RETRY_DURATION;)
+retry_count=$(get_env $RETRY_COUNT;)
 
 #Verify that the datadir used by the templates is mounted
-if ! df -h -P | grep -q datadir > /dev/null 2>&1; then
-    echo -e "datadir not mounted successfully, exiting \n"
-    exit 1
-fi
+counter=0
 
 # Start dd I/O 
-for i in {1..10}
-do
-   echo -e "\nRunning dd profile test with size=$TEST_SIZE ... Wait for results !!\n"
-   dd if=/dev/urandom of=/datadir/f$i bs=$TEST_SIZE count=$TEST_COUNT oflag=dsync 
-done  
-sleep 10
-rm -rf /datadir/*
+while true
+do 
+   podName=$(kubectl get pod -n $namespace -l $app_label --no-headers -ojsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' | head -1)
+   if [ -z "$podName" ]; then
+      echo "Unable to get pod Name. Retrying..."
+      counter=$((counter +1))
+      sleep $retry_duration
+      if [ "$counter" -gt "$retry_count" ]; then
+         exit 1;
+      fi
+   else
+   echo "Writing data on $mountPoint"
+   randomString=$(echo $RANDOM | tr '[0-9]' '[a-z]')
+   kubectl exec $podName -n $namespace -- sh -c "cd $mountPoint && dd if=/dev/urandom of=test.$randomString bs=$blockSize count=$count"  
+   sleep 10
+   counter=0
+   fi
+done

--- a/tpcc-client/Dockerfile
+++ b/tpcc-client/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
   gcc \
   libc6-dev \
   zlib1g-dev \
+  libssl-dev \
   make \
   libmysqlclient-dev
 


### PR DESCRIPTION
Signed-off-by: shashank855 <ranjanshashank855@gmail.com>

**What this PR does / why we need it**:

- Adds a custom dd-client which act as generic loadgen client for kubernetes applications.

**Following the container log**:
```
Writing data on /var/lib/mysql
0+0 records in
0+0 records out
0 bytes copied, 0.000159033 s, 0.0 kB/s
Writing data on /var/lib/mysql
0+0 records in
0+0 records out
0 bytes copied, 0.000154041 s, 0.0 kB/s
Writing data on /var/lib/mysql
0+0 records in
0+0 records out
0 bytes copied, 7.1377e-05 s, 0.0 kB/s
Unable to get pod Name. Retrying...
Unable to get pod Name. Retrying...
Writing data on /var/lib/mysql
2+0 records in
2+0 records out
8192 bytes (8.2 kB, 8.0 KiB) copied, 0.000228296 s, 35.9 MB/s
Unable to get pod Name. Retrying...
Writing data on /var/lib/mysql
3+0 records in
3+0 records out
12288 bytes (12 kB, 12 KiB) copied, 0.000421306 s, 29.2 MB/s
Unable to get pod Name. Retrying...
Writing data on /var/lib/mysql
4+0 records in
4+0 records out
16384 bytes (16 kB, 16 KiB) copied, 0.000488998 s, 33.5 MB/s
Writing data on /var/lib/mysql
4+0 records in
4+0 records out
16384 bytes (16 kB, 16 KiB) copied, 0.00070192 s, 23.3 MB/s
Writing data on /var/lib/mysql
4+0 records in
4+0 records out
16384 bytes (16 kB, 16 KiB) copied, 0.000449191 s, 36.5 MB/s
```
