### PR TITLE
Updated log message for stopped engine state

### DIFF
--- a/custom/litmus-checker/pkg/chaos-checker/check.go
+++ b/custom/litmus-checker/pkg/chaos-checker/check.go
@@ -26,9 +26,14 @@ func CheckChaos(kubeconfig *string, res k8s.ResourceDef) {
 			continue
 		}
 		engStat, ok := status["engineStatus"].(string)
-		if ok && (strings.ToLower(engStat) == "completed" || strings.ToLower(engStat) == "stopped") {
-			log.Print("ENGINE COMPLETED")
-			return
+		if ok {
+			if strings.ToLower(engStat) == "completed" {
+				log.Print("[*] ENGINE COMPLETED")
+				return
+			} else if strings.ToLower(engStat) == "stopped" {
+				log.Print("[!] ERROR : ENGINE STATUS STOPPED")
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Soumya Ghosh Dastidar <gdsoumya@gmail.com>

**What this PR does / why we need it**:

This PR updates the log message for stopped engine state in litmus-checker, this will provide more insight to the users incase there are no other experiment logs available.