### PR TITLE
Added Podtato-head application for Pre-Defined Workflow installation

### DIFF
--- a/custom/git-app-deployer/Dockerfile
+++ b/custom/git-app-deployer/Dockerfile
@@ -19,8 +19,9 @@ RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LAT
 
 COPY resilient-sock-shop.yaml /var/run
 COPY weak-sock-shop.yaml /var/run
-COPY load-test.yaml /var/run
-
+COPY loadtest.yaml /var/run
+COPY resilient-podtato-head.yaml /var/run
+COPY weak-podtato-head.yaml /var/run
 COPY --from=builder /output/deployer /var/run
 
 ENTRYPOINT ["/var/run/deployer"]

--- a/custom/git-app-deployer/loadtest.yaml
+++ b/custom/git-app-deployer/loadtest.yaml
@@ -3,18 +3,18 @@ kind: Deployment
 metadata:
   name: load-test
   labels:
-    app: sock-shop
+    app: loadtest
     name: load-test
   namespace: loadtest
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: sock-shop
+      app: loadtest
   template:
     metadata:
       labels:
-        app: sock-shop
+        app: loadtest
         name: load-test
     spec:
       containers:

--- a/custom/git-app-deployer/main.go
+++ b/custom/git-app-deployer/main.go
@@ -97,7 +97,7 @@ func GetData() (*AppVars, error) {
 		timeout:   *timeout,
 		operation: *operation,
 		label:     "app=" + *app,
-		app:       *app
+		app:       *app,
 	}
 	//application namespace having weak and resilient filePath
 	//loadtest namespace having loadtest filePath

--- a/custom/git-app-deployer/resilient-podtato-head.yaml
+++ b/custom/git-app-deployer/resilient-podtato-head.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    litmuschaos.io/chaos: "true"
+  labels:
+    app: podtato-head
+    name: podtato
+  name: podtato
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: podtato-head
+      name: podtato
+  template:
+    metadata:
+      labels:
+        app: podtato-head
+        name: podtato
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: podtato
+        image: ghcr.io/podtato-head/podtatoserver:v0.1.1
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9000
+        env:
+        - name: PORT
+          value: "9000"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 9000
+          initialDelaySeconds: 10
+          periodSeconds: 3
+                    
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: podtato
+  labels:
+    name: podtato
+spec:
+  selector:
+    app: podtato-head
+  ports:
+  - name: http
+    port: 9000
+    protocol: TCP
+    targetPort: 9000
+  type: LoadBalancer

--- a/custom/git-app-deployer/weak-podtato-head.yaml
+++ b/custom/git-app-deployer/weak-podtato-head.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    litmuschaos.io/chaos: "true"
+  labels:
+    app: podtato-head
+    name: podtato
+  name: podtato
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: podtato-head
+      name: podtato
+  template:
+    metadata:
+      labels:
+        app: podtato-head
+        name: podtato
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: podtato
+        image: ghcr.io/podtato-head/podtatoserver:v0.1.1
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9000
+        env:
+        - name: PORT
+          value: "9000"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 9000
+          initialDelaySeconds: 10
+          periodSeconds: 3
+                    
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: podtato
+  labels:
+    name: podtato
+spec:
+  selector:
+    app: podtato-head
+  ports:
+  - name: http
+    port: 9000
+    protocol: TCP
+    targetPort: 9000
+  type: LoadBalancer


### PR DESCRIPTION
Signed-off-by: Oum Kale <oumkale@chaosnative.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR is adding podtato-head application installation support for workflow installation.


Logs : 
```
W0412 06:23:29.254854       1 client_config.go:541] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
time='2021-04-12T06:23:29Z' level=info msg='[Start]: Starting App Deployer...'
time='2021-04-12T06:23:29Z' level=info msg='[Status]: FilePath for App Deployer is resilient-podtato-head.yaml'
time='2021-04-12T06:23:29Z' level=info msg='[Status]: Namespace already exist'
time='2021-04-12T06:23:29Z' level=info msg='[Status]: Checking whether application containers are in ready state'
time='2021-04-12T06:23:43Z' level=info msg='[Status]: The running status of container are as follows' Pod=podtato-7678c88c78-48nlr Readiness=true container=podtato
time='2021-04-12T06:23:43Z' level=info msg='[Status]: The running status of container are as follows' Pod=podtato-7678c88c78-6bvss Readiness=true container=podtato
time='2021-04-12T06:23:43Z' level=info msg='[Status]: Checking whether application pods are in running state'
time='2021-04-12T06:23:43Z' level=info msg='[Status]: The running status of Pods are as follows' Pod=podtato-7678c88c78-48nlr Status=Running
time='2021-04-12T06:23:43Z' level=info msg='[Status]: The running status of Pods are as follows' Pod=podtato-7678c88c78-6bvss Status=Running
time='2021-04-12T06:23:43Z' level=info msg='[Status]: podtato-head applications has been successfully created'
```