### PR TITLE
Added namespace scope flag for litmus-app-deployer

### DIFF
--- a/custom/git-app-deployer/main.go
+++ b/custom/git-app-deployer/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/litmuschaos/test-tools/pkg/log"

--- a/custom/git-app-deployer/main.go
+++ b/custom/git-app-deployer/main.go
@@ -90,7 +90,7 @@ func GetData() (*AppVars, error) {
 	timeout := flag.Int("timeout", 300, "timeout for application status")
 	operation := flag.String("operation", "apply", "type of operation for application")
 	app := flag.String("app", "", "type of app for application")
-	scope := flag.String("scope", "", "type of scope for application")
+	scope := flag.String("scope", "cluster", "scope of the application")
 	flag.Parse()
 
 	appVars := AppVars{
@@ -162,7 +162,7 @@ func CreateApplication(appVars *AppVars, delay int, clientset *kubernetes.Client
 
 	log.Infof("[Status]: FilePath for App Deployer is %v", appVars.filePath)
 
-	switch appVars.scope {
+	switch strings.ToLower(appVars.scope) {
 	case "cluster":
 		if err := CreateNamespace(clientset, appVars.namespace); err != nil {
 			if !k8serrors.IsAlreadyExists(err) {
@@ -173,7 +173,7 @@ func CreateApplication(appVars *AppVars, delay int, clientset *kubernetes.Client
 			log.Info("[Status]: Namespace created successfully")
 		}
 	case "namespace":
-		log.Infof("[Status]: Application is using namespace %v", appVars.namespace)
+		log.Infof("[Status]: Application is using %v namespace", appVars.namespace)
 	default:
 		return fmt.Errorf("Scope '%v' not supported in app-deployer", appVars.scope)
 	}


### PR DESCRIPTION
Signed-off-by: Oum Kale <oumkale@chaosnative.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

 - Added namespace scope flag for ```litmus-app-deployer```.
 - Now supported for namespace/cluster scope installation.
 - This flag is added to support namescope installation of litmus application and cluster scope as well.
 - ```-scope=namescope``` will deploy(app-deployer) in agent namespace.  And for cluster scope will be in given namespace. 
**Special notes for your reviewer**:
