### PR TITLE
Added Fix for App-deployer Dockerfile and Service type change

### DIFF
--- a/custom/workflow-helper/app-deployer/Dockerfile
+++ b/custom/workflow-helper/app-deployer/Dockerfile
@@ -18,6 +18,7 @@ RUN CGO_ENABLED=0 go build -o /output/deployer -v
 
 #Deploy Stage
 FROM alpine:latest
+ARG TARGETARCH
 
 RUN apk add curl
 

--- a/custom/workflow-helper/app-deployer/resilient-podtato-head.yaml
+++ b/custom/workflow-helper/app-deployer/resilient-podtato-head.yaml
@@ -52,7 +52,7 @@ spec:
     port: 9000
     protocol: TCP
     targetPort: 9000
-  type: LoadBalancer
+  type: NodePort
 
 ---
 apiVersion: apps/v1

--- a/custom/workflow-helper/app-deployer/resilient-sock-shop.yaml
+++ b/custom/workflow-helper/app-deployer/resilient-sock-shop.yaml
@@ -335,7 +335,7 @@ metadata:
     name: front-end
   namespace: sock-shop
 spec:
-  type: LoadBalancer
+  type: NodePort
   ports:
   - port: 80
     targetPort: 8079

--- a/custom/workflow-helper/app-deployer/weak-podtato-head.yaml
+++ b/custom/workflow-helper/app-deployer/weak-podtato-head.yaml
@@ -52,7 +52,7 @@ spec:
     port: 9000
     protocol: TCP
     targetPort: 9000
-  type: LoadBalancer
+  type: NodePort
 
 ---
 apiVersion: apps/v1

--- a/custom/workflow-helper/app-deployer/weak-sock-shop.yaml
+++ b/custom/workflow-helper/app-deployer/weak-sock-shop.yaml
@@ -333,7 +333,7 @@ metadata:
     name: front-end
   namespace: sock-shop
 spec:
-  type: LoadBalancer
+  type: NodePort
   ports:
   - port: 80
     targetPort: 8079


### PR DESCRIPTION
Signed-off-by: Jonsy13 <vedant.shrotria@chaosnative.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**This PR will add**
- Fix for App-deployer Dockerfile for Multiarch support.
- changes the default Service type for services pod-tato(main) and sockshop(frontend) from loadBalancer to NodePort.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
