### PR TITLE
Updating metrics query checker to pod level

### DIFF
--- a/custom/workflow-helper/app-qps-test/go.mod
+++ b/custom/workflow-helper/app-qps-test/go.mod
@@ -2,4 +2,9 @@ module test-tools/release/qpslitmus/qps/QPS
 
 go 1.15
 
-require github.com/litmuschaos/test-tools v1.8.0 // indirect
+require (
+	github.com/litmuschaos/test-tools v1.8.0
+	github.com/pkg/errors v0.9.1
+	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
+	k8s.io/client-go v0.0.0-20190918200256-06eb1244587a
+)

--- a/custom/workflow-helper/app-qps-test/main.go
+++ b/custom/workflow-helper/app-qps-test/main.go
@@ -14,6 +14,11 @@ import (
 	"time"
 
 	"github.com/litmuschaos/test-tools/pkg/log"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 //QPSVars will carry all the params for functionality of end point
@@ -22,13 +27,19 @@ type QPSVars struct {
 	totalQueries  int
 	qpsValue      string
 	totalReqCount string
+	namespace     string
+	appLabel      string
+	timeInterval  int
+	route         string
+	urlList       []string
+	query         string
 }
 
 func main() {
 	log.Info("[Status]: Starting QPS provider...")
 
 	qpsVars := initialiseVars()
-
+	log.Info("[Status]: intialised")
 	go runDataLoop(qpsVars)
 
 	// Create a handler that will read-lock the mutext and
@@ -50,6 +61,12 @@ func initialiseVars() (vars *QPSVars) {
 		totalQueries:  0,
 		qpsValue:      "0",
 		totalReqCount: "0",
+		namespace:     os.Getenv("APP_NAMESPACE"),
+		appLabel:      os.Getenv("APP_LABEL"),
+		timeInterval:  0,
+		route:         os.Getenv("ROUTE"),
+		query:         os.Getenv("QUERY"),
+		urlList:       []string{},
 	}
 	return &qpsVars
 }
@@ -57,11 +74,19 @@ func initialiseVars() (vars *QPSVars) {
 // It will count the mean value of total queries available in given time interval and update
 // end point with query per second(qpsValue).
 func runDataLoop(vars *QPSVars) {
-	queue := list.New()
 
-	timeInterval, _ := strconv.Atoi(os.Getenv("TIME")) //The time period in second to calculate mean value of QPS.
-	url := os.Getenv("URL")                            //URL of endpoint metics
-	route := os.Getenv("ROUTE")                        //route is a endpoint of application to get qpsValue
+	config, err := getKubeConfig()
+	if err != nil {
+		return
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return
+	}
+
+	queue := list.New()
+	vars.timeInterval, _ = strconv.Atoi(os.Getenv("TIME")) //The time period in second to calculate mean value of QPS.
 	flag.Parse()
 
 	// Within an infinite loop, lock the mutex and
@@ -69,10 +94,13 @@ func runDataLoop(vars *QPSVars) {
 	// the next time we need to get a value.
 	start := time.Now()
 	for {
-
-		req, err := GetRequests(url, route, vars)
+		vars.urlList, err = getURL(vars, clientset)
 		if err != nil {
-			log.Errorf("err: %v", err)
+			log.Errorf("Unable to find the pods in namespace, err: %v", err)
+			continue
+		}
+		req, err := GetRequests(vars.urlList, vars.route, vars)
+		if err != nil {
 			vars.qpsValue = strconv.Itoa(0)
 			time.Sleep(1 * time.Second)
 			continue
@@ -80,9 +108,10 @@ func runDataLoop(vars *QPSVars) {
 
 		second := int(time.Now().Sub(start).Seconds())
 		reqs, _ := strconv.Atoi(req)
+		vars.totalReqCount = "0"
 		vars.totalQueries = reqs
 
-		if second <= timeInterval {
+		if second <= vars.timeInterval {
 			queue.PushBack(reqs)
 			vars.qpsValue = strconv.Itoa(int(math.Abs(float64(100 * (reqs / queue.Len())))))
 		} else {
@@ -90,7 +119,7 @@ func runDataLoop(vars *QPSVars) {
 			queue.Remove(front)
 			queue.PushBack(reqs)
 			vars.totalQueries -= front.Value.(int)
-			vars.qpsValue = strconv.Itoa(int(math.Abs(float64(100 * (vars.totalQueries / timeInterval)))))
+			vars.qpsValue = strconv.Itoa(int(math.Abs(float64(100 * (vars.totalQueries / vars.timeInterval)))))
 		}
 		log.Infof("[Status]: Current total requests : ", req)
 		log.Infof("[Status]: Current QPS value is   : ", vars.qpsValue)
@@ -98,30 +127,54 @@ func runDataLoop(vars *QPSVars) {
 	}
 }
 
+// getURL will list the IPs for all the pods exporting metrics
+func getURL(vars *QPSVars, clientset *kubernetes.Clientset) ([]string, error) {
+	vars.urlList = []string{}
+	podSpec, err := clientset.CoreV1().Pods(vars.namespace).List(metav1.ListOptions{LabelSelector: vars.appLabel})
+	if err != nil {
+		return []string{}, errors.Errorf("Unable to find the pods in namespace, err: %v", err)
+	}
+	for _, pod := range podSpec.Items {
+		vars.urlList = append(vars.urlList, strings.Replace(pod.Status.PodIP, ".", "-", -1))
+	}
+	return vars.urlList, nil
+}
+
 //GetRequests will fetch the response from metrics and calculate the total requests from front-end of sock-shop.
-func GetRequests(url string, route string, vars *QPSVars) (string, error) {
+func GetRequests(urlList []string, route string, vars *QPSVars) (string, error) {
 
-	response, err := http.Get(url)
-	if err != nil {
-		return "", err
-	}
-	defer response.Body.Close()
+	for index := range urlList {
+		response, err := http.Get(string("http://" + urlList[index] + "." + vars.route))
+		if err != nil {
+			return "", err
+		}
+		defer response.Body.Close()
 
-	metric, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return "", err
-	}
+		metric, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			return "", err
+		}
 
-	metrics := string(metric)
-	metricsSplited := strings.Split(metrics, "\n")
-
-	for i := 0; i < len(metricsSplited); i++ {
-		if strings.Contains(string(metricsSplited[i]), `request_duration_seconds_count{service="front-end",method="get",route="`+route+`",status_code="200`) {
-			metricsValue := strings.Split(metricsSplited[i], " ")
-			vars.totalReqCount = metricsValue[1]
-			return vars.totalReqCount, nil
+		metrics := string(metric)
+		metricsSplited := strings.Split(metrics, "\n")
+		for i := 0; i < len(metricsSplited); i++ {
+			if strings.Contains(string(metricsSplited[i]), vars.query) {
+				metricsValue := strings.Split(metricsSplited[i], " ")
+				currentCount, _ := strconv.Atoi(vars.totalReqCount)
+				newCount, _ := strconv.Atoi(metricsValue[1])
+				totalCount := currentCount + newCount
+				vars.totalReqCount = strconv.Itoa(totalCount)
+			}
 		}
 	}
+	return vars.totalReqCount, nil
+}
 
-	return vars.totalReqCount, fmt.Errorf("Provided route is incorrect")
+// GetKubeConfig function derive the kubeconfig
+func getKubeConfig() (*rest.Config, error) {
+	kubeconfig := flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	flag.Parse()
+	// It uses in-cluster config if kubeconfig path is not specified
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	return config, err
 }


### PR DESCRIPTION
Signed-off-by: Oum Kale <oumkale@chaosnative.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR is adding all the replicas metrics to get sum of the query.
Earlier it is used to calculate only one single replica metrics  
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Updating metrics query checker to pod level
 - It will list all the pod IP and fetch their individual metrics to sum the accurate query