### PR TITLE
Chore(pumba): Fix image vulnerability of pumba with latest version 0.8.0

### DIFF
--- a/custom/hardened-alpine/experiment/Dockerfile
+++ b/custom/hardened-alpine/experiment/Dockerfile
@@ -54,7 +54,7 @@ RUN curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.16
     tar zxvf crictl-v1.16.0-linux-${TARGETARCH}.tar.gz -C /usr/local/bin
     
 #Installing pumba binaries
-ENV PUMBA_VERSION="0.7.7"
+ENV PUMBA_VERSION="0.8.0"
 RUN curl -L https://github.com/alexei-led/pumba/releases/download/${PUMBA_VERSION}/pumba_linux_${TARGETARCH} --output /usr/local/bin/pumba && chmod +x /usr/local/bin/pumba
 
 #Installing promql cli binaries


### PR DESCRIPTION
Signed-off-by: udit <udit@chaosnative.com>
**What this PR does / why we need it**:

- This PR will update the Pumba image with version 0.8.0 which has the fix for the high-security vulnerability.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
