### PR TITLE
feat: change app,data&conf dir to 0(root) group so it's openshift fri…

### DIFF
--- a/custom/hardened-alpine/infra/Dockerfile
+++ b/custom/hardened-alpine/infra/Dockerfile
@@ -37,7 +37,10 @@ RUN apk add --no-cache ca-certificates
 RUN adduser -s /bin/true -u 1000 -D -h $APP_DIR $APP_USER \
   && mkdir "$DATA_DIR" "$CONF_DIR" \
   && chown -R "$APP_USER" "$APP_DIR" "$CONF_DIR" \
-  && chmod 700 "$APP_DIR" "$DATA_DIR" "$CONF_DIR"
+  && chmod 700 "$APP_DIR" "$DATA_DIR" "$CONF_DIR" \
+# change to 0(root) group because openshift will run container with arbitrary uid as a member of root group
+  && chgrp -R 0 "$APP_DIR" "$DATA_DIR" "$CONF_DIR" \
+  && chmod -R g=u "$APP_DIR" "$DATA_DIR" "$CONF_DIR"
 
 # Remove existing crontabs, if any.
 RUN rm -fr /var/spool/cron \


### PR DESCRIPTION
…endly

Context: openshift run container with an arbitrary uid that in the root group. we want that arbitrary container user to have full access to /litmus so we can change the permission of the folder in /litmus to be litmus:0 (edited) 

it's simmilar with what nginx-unprivileged is doing as well https://github.com/nginxinc/docker-nginx-unprivileged/pull/10

if other apps using this as base and create other dir, they need to do the same as well.

related thread on slack: https://kubernetes.slack.com/archives/CNXNB0ZTN/p1635924872263900

Signed-off-by: Tuan Anh Tran <me@tuananh.org>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

to make it openshift friendly, without the need to add `anyuid` security context to graphql server service account

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
related thread on slack: https://kubernetes.slack.com/archives/CNXNB0ZTN/p1635924872263900
