### PR TITLE
Adding setup for deploying a container with kind cluster & a local registry configured for air-gapped testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -561,7 +561,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.air-gapped-kind == 'true'
-    # Note: While updating these envs, make sure update the same in dockerfile
+    # Note: While updating these envs, make sure update the same in entrypoint-wrapper.sh
     env:
       KIND_NODE_IMAGE: "kindest/node:v1.21.1"
       REGISTRY_IMAGE: "registry:2"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 defaults:
   run:
-    shell: bash        
+    shell: bash
 
 jobs:
   shell-checker:
@@ -20,13 +20,12 @@ jobs:
       - name: checking syntax of shell script
         run: bash -c 'shopt -s globstar nullglob; shellcheck **/*.{sh,ksh,bash}' || true
 
-
   changes:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     # this is done to run the selective jobs based on the code change
     outputs:
-      kafka-deployer: ${{ steps.filter.outputs.kafka-deployer }}       
+      kafka-deployer: ${{ steps.filter.outputs.kafka-deployer }}
       forkbomb: ${{ steps.filter.outputs.forkbomb }}
       fio: ${{ steps.filter.outputs.fio }}
       mysql-client: ${{ steps.filter.outputs.mysql-client }}
@@ -54,19 +53,21 @@ jobs:
       litmus-k8s: ${{ steps.filter.outputs.litmus-k8s }}
       litmus-curl: ${{ steps.filter.outputs.litmus-curl }}
       litmus-checker: ${{ steps.filter.outputs.litmus-checker }}
-      litmus-argocli: ${{ steps.filter.outputs.litmus-argocli }}   
-      workflow-controller: ${{ steps.filter.outputs.workflow-controller }}   
-      argoexec: ${{ steps.filter.outputs.argoexec }}                                                
-      mongo: ${{ steps.filter.outputs.mongo }}   
+      litmus-argocli: ${{ steps.filter.outputs.litmus-argocli }}
+      workflow-controller: ${{ steps.filter.outputs.workflow-controller }}
+      argoexec: ${{ steps.filter.outputs.argoexec }}
+      mongo: ${{ steps.filter.outputs.mongo }}
       litmus-pg-load: ${{ steps.filter.outputs.litmus-pg-load }}
       litmus-experiment-hardened-alpine: ${{ steps.filter.outputs.litmus-experiment-hardened-alpine }}
       litmus-infra-hardened-alpine: ${{ steps.filter.outputs.litmus-infra-hardened-alpine }}
       litmus-pg-jmeter: ${{ steps.filter.outputs.litmus-pg-jmeter }}
-      mongo-utils: ${{ steps.filter.outputs.mongo-utils }}  
+      mongo-utils: ${{ steps.filter.outputs.mongo-utils }}
+      air-gapped-kind: ${{ steps.filter.outputs.air-gapped-kind }}
+
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}    
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -143,6 +144,8 @@ jobs:
               - 'custom/workflow-helper/postgres-helper/jmeter/**'
             mongo-utils:
               - 'custom/mongo-utils/**'
+            air-gapped-kind:
+              - 'custom/air-gapped-kind/**'
 
   litmus-app-deployer:
     runs-on: ubuntu-latest
@@ -273,7 +276,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-                    
+
       - name: Building workflow-controller image
         run: make litmus-argo-workflow-controller
 
@@ -299,7 +302,7 @@ jobs:
 
       - name: Building mongo image
         run: make litmus-mongo
-  
+
   kafka-deployer:
     runs-on: ubuntu-latest
     needs: changes
@@ -310,7 +313,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Building kafka-deployer image
         run: make litmus-kafka-deployer
-
 
   mysql-client:
     runs-on: ubuntu-latest
@@ -520,7 +522,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Building fio image
         run: make fio
-  
+
   litmus-pg-load:
     runs-on: ubuntu-latest
     needs: changes
@@ -554,3 +556,15 @@ jobs:
       - name: Building mongo-utils image
         run: |
           make litmus-mongo-utils
+
+  air-gapped-kind:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.air-gapped-kind == 'true'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Building air-gapped-kind image
+        run: |
+          make air_gapped_kind

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -561,10 +561,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.air-gapped-kind == 'true'
+    # Note: While updating these envs, make sure update the same in dockerfile
+    env:
+      KIND_NODE_IMAGE: "kindest/node:v1.21.1"
+      REGISTRY_IMAGE: "registry:2"
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Pulling Node & Registry images
+        run: |
+          mkdir custom/air-gapped-kind/assets
+          docker pull ${KIND_NODE_IMAGE} && docker save ${KIND_NODE_IMAGE} | gzip > custom/air-gapped-kind/assets/node.tar.gz
+          docker pull ${REGISTRY_IMAGE} && docker save ${REGISTRY_IMAGE} | gzip > custom/air-gapped-kind/assets/registry.tar.gz
+
       - name: Building air-gapped-kind image
         run: |
           make air_gapped_kind

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -597,10 +597,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.air-gapped-kind == 'true'
+    # Note: While updating these envs, make sure update the same in dockerfile
+    env:
+      KIND_NODE_IMAGE: "kindest/node:v1.21.1"
+      REGISTRY_IMAGE: "registry:2"
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Pulling Node & Registry images
+        run: |
+          mkdir custom/air-gapped-kind/assets
+          docker pull ${KIND_NODE_IMAGE} && docker save ${KIND_NODE_IMAGE} | gzip > custom/air-gapped-kind/assets/node.tar.gz
+          docker pull ${REGISTRY_IMAGE} && docker save ${REGISTRY_IMAGE} | gzip > custom/air-gapped-kind/assets/registry.tar.gz
+
       - name: Building air-gapped-kind image
         run: |
           make docker.buildx

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,11 +58,12 @@ jobs:
       workflow-controller: ${{ steps.filter.outputs.workflow-controller }}
       argoexec: ${{ steps.filter.outputs.argoexec }}
       mongo: ${{ steps.filter.outputs.mongo }}
-      litmus-pg-load: ${{ steps.filter.outputs.litmus-pg-load }} 
+      litmus-pg-load: ${{ steps.filter.outputs.litmus-pg-load }}
       litmus-pg-jmeter: ${{ steps.filter.outputs.litmus-pg-jmeter }}
       litmus-experiment-hardened-alpine: ${{ steps.filter.outputs.litmus-experiment-hardened-alpine }}
       litmus-infra-hardened-alpine: ${{ steps.filter.outputs.litmus-infra-hardened-alpine }}
       mongo-utils: ${{ steps.filter.outputs.mongo-utils }}
+      air-gapped-kind: ${{ steps.filter.outputs.air-gapped-kind }}
 
     steps:
       - uses: actions/checkout@v2
@@ -142,6 +143,8 @@ jobs:
               - 'custom/workflow-helper/postgres-helper/jmeter/**'
             mongo-utils:
               - 'custom/mongo-utils/**'
+            air-gapped-kind:
+              - 'custom/air-gapped-kind/**'
 
   litmus-app-deployer:
     runs-on: ubuntu-latest
@@ -563,7 +566,7 @@ jobs:
         run: |
           make docker.buildx
           make _push_litmus_pg_load
-  
+
   litmus-pg-jmeter:
     runs-on: ubuntu-latest
     needs: changes
@@ -576,7 +579,7 @@ jobs:
         run: |
           make docker.buildx
           make _push_litmus_pg_jmeter
-    
+
   mongo-utils:
     runs-on: ubuntu-latest
     needs: changes
@@ -588,4 +591,17 @@ jobs:
       - name: Building mongo-utils image
         run: |
           make docker.buildx
-          make _push_litmus_mongo_utils 
+          make _push_litmus_mongo_utils
+
+  air-gapped-kind:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.air-gapped-kind == 'true'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Building air-gapped-kind image
+        run: |
+          make docker.buildx
+          make _push_air_gapped_kind

--- a/Makefile
+++ b/Makefile
@@ -406,12 +406,12 @@ _push_litmus_mongo_utils:
 litmus-mongo-utils: deps _build_litmus_mongo_utils _push_litmus_mongo_utils
 
 _build_air_gapped_kind:
-	@echo "INFO: Building container image for litmuschaos/air_gapped_kind"
-	cd custom/air_gapped_kind && docker build -t litmuschaos/air_gapped_kind .
+	@echo "INFO: Building container image for litmuschaos/air-gapped-kind"
+	cd custom/air-gapped-kind && docker build -t litmuschaos/air-gapped-kind .
 
 _push_air_gapped_kind:
-	@echo "INFO: Publish container litmuschaos/air_gapped_kind"
-	cd custom/air_gapped_kind && ./buildscripts/push
+	@echo "INFO: Publish container litmuschaos/air-gapped-kind"
+	cd custom/air-gapped-kind && ./buildscripts/push
 
 air_gapped_kind: deps _build_air_gapped_kind _push_air_gapped_kind
 

--- a/Makefile
+++ b/Makefile
@@ -405,6 +405,16 @@ _push_litmus_mongo_utils:
 
 litmus-mongo-utils: deps _build_litmus_mongo_utils _push_litmus_mongo_utils
 
+_build_air_gapped_kind:
+	@echo "INFO: Building container image for litmuschaos/air_gapped_kind"
+	cd custom/air_gapped_kind && docker build -t litmuschaos/air_gapped_kind .
+
+_push_air_gapped_kind:
+	@echo "INFO: Publish container litmuschaos/air_gapped_kind"
+	cd custom/air_gapped_kind && ./buildscripts/push
+
+air_gapped_kind: deps _build_air_gapped_kind _push_air_gapped_kind
+
 PHONY: go-build
 go-build: experiment-go-binary
 

--- a/custom/air-gapped-kind/Dockerfile
+++ b/custom/air-gapped-kind/Dockerfile
@@ -46,9 +46,9 @@ RUN set -eux; \
   dockerd --version; \
   docker --version
 
-COPY build/air-gapped/modprobe.sh /usr/local/bin/modprobe
+COPY modprobe.sh /usr/local/bin/modprobe
 RUN chmod +x /usr/local/bin/modprobe
-COPY build/air-gapped/docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # https://github.com/docker-library/docker/pull/166
@@ -98,7 +98,7 @@ RUN set -eux; \
   wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
   chmod +x /usr/local/bin/dind
 
-COPY build/air-gapped/dockerd-entrypoint.sh /usr/local/bin/
+COPY dockerd-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh
 
 VOLUME /var/lib/docker
@@ -121,8 +121,8 @@ RUN apk update && \
 RUN 
 
 COPY ./assets/ ./assets/
-COPY build/air-gapped/kind-config.yml ./kind-config.yml
-COPY build/air-gapped/entrypoint-wrapper.sh ./entrypoint-wrapper.sh
+COPY kind-config.yml ./kind-config.yml
+COPY entrypoint-wrapper.sh ./entrypoint-wrapper.sh
 
 RUN chmod +x ./entrypoint-wrapper.sh
 

--- a/custom/air-gapped-kind/Dockerfile
+++ b/custom/air-gapped-kind/Dockerfile
@@ -118,8 +118,6 @@ RUN apk update && \
     tar -xvf /tmp/helm.tar.gz && \
     mv ./linux-amd64/helm /usr/bin/helm
 
-RUN 
-
 COPY ./assets/ ./assets/
 COPY kind-config.yml ./kind-config.yml
 COPY entrypoint-wrapper.sh ./entrypoint-wrapper.sh

--- a/custom/air-gapped-kind/Dockerfile
+++ b/custom/air-gapped-kind/Dockerfile
@@ -1,0 +1,129 @@
+FROM alpine:3.15
+
+WORKDIR /air-gapped-kind
+
+RUN apk add --no-cache ca-certificates openssh-client
+
+# set up nsswitch.conf for Go's "netgo" implementation (which Docker explicitly uses)
+# - https://github.com/docker/docker-ce/blob/v17.09.0-ce/components/engine/hack/make.sh#L149
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
+ENV DOCKER_VERSION 20.10.7
+# TODO ENV DOCKER_SHA256
+# https://github.com/docker/docker-ce/blob/5b073ee2cf564edee5adca05eee574142f7627bb/components/packaging/static/hash_files !!
+# (no SHA file artifacts on download.docker.com yet as of 2017-06-07 though)
+
+RUN set -eux; \
+  \
+  apkArch="$(apk --print-arch)"; \
+  case "$apkArch" in \
+    'x86_64') \
+      url='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.7.tgz'; \
+      ;; \
+    'armhf') \
+      url='https://download.docker.com/linux/static/stable/armel/docker-20.10.7.tgz'; \
+      ;; \
+    'armv7') \
+      url='https://download.docker.com/linux/static/stable/armhf/docker-20.10.7.tgz'; \
+      ;; \
+    'aarch64') \
+      url='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.7.tgz'; \
+      ;; \
+    *) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;; \
+  esac; \
+  \
+  wget -O docker.tgz "$url"; \
+  \
+  tar --extract \
+    --file docker.tgz \
+    --strip-components 1 \
+    --directory /usr/local/bin/ \
+  ; \
+  rm docker.tgz; \
+  \
+  dockerd --version; \
+  docker --version
+
+COPY build/air-gapped/modprobe.sh /usr/local/bin/modprobe
+RUN chmod +x /usr/local/bin/modprobe
+COPY build/air-gapped/docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# https://github.com/docker-library/docker/pull/166
+#   dockerd-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-generating TLS certificates
+#   docker-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-setting DOCKER_TLS_VERIFY and DOCKER_CERT_PATH
+# (For this to work, at least the "client" subdirectory of this path needs to be shared between the client and server containers via a volume, "docker cp", or other means of data sharing.)
+ENV DOCKER_TLS_CERTDIR=/certs
+# also, ensure the directory pre-exists and has wide enough permissions for "dockerd-entrypoint.sh" to create subdirectories, even when run in "rootless" mode
+RUN mkdir /certs /certs/client && chmod 1777 /certs /certs/client
+# (doing both /certs and /certs/client so that if Docker does a "copy-up" into a volume defined on /certs/client, it will "do the right thing" by default in a way that still works for rootless users)
+
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
+RUN set -eux; \
+  apk add --no-cache \
+    btrfs-progs \
+    e2fsprogs \
+    e2fsprogs-extra \
+    ip6tables \
+    iptables \
+    openssl \
+    shadow-uidmap \
+    xfsprogs \
+    xz \
+# pigz: https://github.com/moby/moby/pull/35697 (faster gzip implementation)
+    pigz \
+  ; \
+# only install zfs if it's available for the current architecture
+# https://git.alpinelinux.org/cgit/aports/tree/main/zfs/APKBUILD?h=3.6-stable#n9 ("all !armhf !ppc64le" as of 2017-11-01)
+# "apk info XYZ" exits with a zero exit code but no output when the package exists but not for this arch
+  if zfs="$(apk info --no-cache --quiet zfs)" && [ -n "$zfs" ]; then \
+    apk add --no-cache zfs; \
+  fi
+
+# TODO aufs-tools
+
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+RUN set -eux; \
+  addgroup -S dockremap; \
+  adduser -S -G dockremap dockremap; \
+  echo 'dockremap:165536:65536' >> /etc/subuid; \
+  echo 'dockremap:165536:65536' >> /etc/subgid
+
+# https://github.com/docker/docker/tree/master/hack/dind
+ENV DIND_COMMIT 42b1175eda071c0e9121e1d64345928384a93df1
+
+RUN set -eux; \
+  wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
+  chmod +x /usr/local/bin/dind
+
+COPY build/air-gapped/dockerd-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh
+
+VOLUME /var/lib/docker
+EXPOSE 2375 2376
+
+ARG KUBECTL_VERSION="v1.21.1"
+ARG KIND_VERSION="v0.11.1"
+ARG HELM_VERSION="v3.1.1"
+
+RUN apk update && \
+    apk add curl bash findutils && \
+    curl -Lso /usr/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    chmod +x /usr/bin/kubectl && \
+    curl -Lso /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64" && \
+    chmod +x /usr/bin/kind && \
+    curl -Lso /tmp/helm.tar.gz "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" && \
+    tar -xvf /tmp/helm.tar.gz && \
+    mv ./linux-amd64/helm /usr/bin/helm
+
+RUN 
+
+COPY ./assets/ ./assets/
+COPY build/air-gapped/kind-config.yml ./kind-config.yml
+COPY build/air-gapped/entrypoint-wrapper.sh ./entrypoint-wrapper.sh
+
+RUN chmod +x ./entrypoint-wrapper.sh
+
+ENTRYPOINT ["./entrypoint-wrapper.sh"]

--- a/custom/air-gapped-kind/buildscripts/push
+++ b/custom/air-gapped-kind/buildscripts/push
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# While making any change in below variables, Please edit the enrtypoint-wrapper.sh as well
+KIND_NODE_IMAGE="kindest/node:v1.21.1"
+REGISTRY_IMAGE="registry:2"
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
+then
+  docker login -u "${DNAME}" -p "${DPASS}";
+  
+  # Pulling Node & Registry images
+  mkdir assets
+  docker pull kindest/node:v1.21.1 && docker save ${KIND_NODE_IMAGE} -o assets/node.tar
+  docker pull registry:2 && docker save ${REGISTRY_IMAGE} -o assets/registry.tar
+
+  #Push to docker hub repository with latest tag
+  docker buildx build -f Dockerfile --progress plane --push --no-cache --platform linux/amd64,linux/arm64 --tag litmuschaos/air-gapped-kind:latest .
+else
+  echo "No docker credentials provided. Skip uploading litmuschaos/air-gapped-kind:latest to docker hub";
+fi;

--- a/custom/air-gapped-kind/buildscripts/push
+++ b/custom/air-gapped-kind/buildscripts/push
@@ -1,18 +1,9 @@
 #!/bin/bash
 set -e
 
-# While making any change in below variables, Please edit the enrtypoint-wrapper.sh as well
-KIND_NODE_IMAGE="kindest/node:v1.21.1"
-REGISTRY_IMAGE="registry:2"
-
 if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
 then
   docker login -u "${DNAME}" -p "${DPASS}";
-  
-  # Pulling Node & Registry images
-  mkdir assets
-  docker pull kindest/node:v1.21.1 && docker save ${KIND_NODE_IMAGE} -o assets/node.tar
-  docker pull registry:2 && docker save ${REGISTRY_IMAGE} -o assets/registry.tar
 
   #Push to docker hub repository with latest tag
   docker buildx build -f Dockerfile --progress plane --push --no-cache --platform linux/amd64,linux/arm64 --tag litmuschaos/air-gapped-kind:latest .

--- a/custom/air-gapped-kind/docker-entrypoint.sh
+++ b/custom/air-gapped-kind/docker-entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -eu
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- docker "$@"
+fi
+
+# if our command is a valid Docker subcommand, let's invoke it through Docker instead
+# (this allows for "docker run docker ps", etc)
+if docker help "$1" > /dev/null 2>&1; then
+	set -- docker "$@"
+fi
+
+_should_tls() {
+	[ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/ca.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/cert.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/key.pem" ]
+}
+
+# if we have no DOCKER_HOST but we do have the default Unix socket (standard or rootless), use it explicitly
+if [ -z "${DOCKER_HOST:-}" ] && [ -S /var/run/docker.sock ]; then
+	export DOCKER_HOST=unix:///var/run/docker.sock
+elif [ -z "${DOCKER_HOST:-}" ] && XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}" && [ -S "$XDG_RUNTIME_DIR/docker.sock" ]; then
+	export DOCKER_HOST="unix://$XDG_RUNTIME_DIR/docker.sock"
+fi
+
+# if DOCKER_HOST isn't set (no custom setting, no default socket), let's set it to a sane remote value
+if [ -z "${DOCKER_HOST:-}" ]; then
+	if _should_tls || [ -n "${DOCKER_TLS_VERIFY:-}" ]; then
+		export DOCKER_HOST='tcp://docker:2376'
+	else
+		export DOCKER_HOST='tcp://docker:2375'
+	fi
+fi
+if [ "${DOCKER_HOST#tcp:}" != "$DOCKER_HOST" ] \
+	&& [ -z "${DOCKER_TLS_VERIFY:-}" ] \
+	&& [ -z "${DOCKER_CERT_PATH:-}" ] \
+	&& _should_tls \
+; then
+	export DOCKER_TLS_VERIFY=1
+	export DOCKER_CERT_PATH="$DOCKER_TLS_CERTDIR/client"
+fi
+
+if [ "$1" = 'dockerd' ]; then
+	cat >&2 <<-'EOW'
+		📎 Hey there!  It looks like you're trying to run a Docker daemon.
+		   You probably should use the "dind" image variant instead, something like:
+		     docker run --privileged --name some-docker ... docker:dind ...
+		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
+	EOW
+	sleep 3
+fi
+
+exec "$@"

--- a/custom/air-gapped-kind/dockerd-entrypoint.sh
+++ b/custom/air-gapped-kind/dockerd-entrypoint.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+set -eu
+
+_tls_ensure_private() {
+	local f="$1"; shift
+	[ -s "$f" ] || openssl genrsa -out "$f" 4096
+}
+_tls_san() {
+	{
+		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
+		{
+			cat /etc/hostname
+			echo 'docker'
+			echo 'localhost'
+			hostname -f
+			hostname -s
+		} | sed 's/^/DNS:/'
+		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
+	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
+}
+_tls_generate_certs() {
+	local dir="$1"; shift
+
+	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
+	# if ca/key.pem, generate server public
+	# if ca/key.pem, generate client public
+	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
+
+	# https://github.com/FiloSottile/mkcert/issues/174
+	local certValidDays='825'
+
+	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
+		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
+		mkdir -p "$dir/ca"
+		_tls_ensure_private "$dir/ca/key.pem"
+		openssl req -new -key "$dir/ca/key.pem" \
+			-out "$dir/ca/cert.pem" \
+			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a server key
+		mkdir -p "$dir/server"
+		_tls_ensure_private "$dir/server/key.pem"
+		openssl req -new -key "$dir/server/key.pem" \
+			-out "$dir/server/csr.pem" \
+			-subj '/CN=docker:dind server'
+		cat > "$dir/server/openssl.cnf" <<-EOF
+			[ x509_exts ]
+			subjectAltName = $(_tls_san)
+		EOF
+		openssl x509 -req \
+				-in "$dir/server/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/server/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/server/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a client key
+		mkdir -p "$dir/client"
+		_tls_ensure_private "$dir/client/key.pem"
+		chmod 0644 "$dir/client/key.pem" # openssl defaults to 0600 for the private key, but this one needs to be shared with arbitrary client contexts
+		openssl req -new \
+				-key "$dir/client/key.pem" \
+				-out "$dir/client/csr.pem" \
+				-subj '/CN=docker:dind client'
+		cat > "$dir/client/openssl.cnf" <<-'EOF'
+			[ x509_exts ]
+			extendedKeyUsage = clientAuth
+		EOF
+		openssl x509 -req \
+				-in "$dir/client/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/client/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/client/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
+		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
+	fi
+}
+
+# no arguments passed
+# or first arg is `-f` or `--some-option`
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	# set "dockerSocket" to the default "--host" *unix socket* value (for both standard or rootless)
+	uid="$(id -u)"
+	if [ "$uid" = '0' ]; then
+		dockerSocket='unix:///var/run/docker.sock'
+	else
+		# if we're not root, we must be trying to run rootless
+		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
+		dockerSocket="unix://$XDG_RUNTIME_DIR/docker.sock"
+	fi
+	case "${DOCKER_HOST:-}" in
+		unix://*)
+			dockerSocket="$DOCKER_HOST"
+			;;
+	esac
+
+	# add our default arguments
+	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \
+	; then
+		# generate certs and use TLS if requested/possible (default in 19.03+)
+		set -- dockerd \
+			--host="$dockerSocket" \
+			--host=tcp://0.0.0.0:2376 \
+			--tlsverify \
+			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
+			--tlscert "$DOCKER_TLS_CERTDIR/server/cert.pem" \
+			--tlskey "$DOCKER_TLS_CERTDIR/server/key.pem" \
+			"$@"
+		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2376:2376/tcp"
+	else
+		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
+		set -- dockerd \
+			--host="$dockerSocket" \
+			--host=tcp://0.0.0.0:2375 \
+			"$@"
+		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"
+	fi
+fi
+
+if [ "$1" = 'dockerd' ]; then
+	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
+	find /run /var/run -iname 'docker*.pid' -delete || :
+
+	uid="$(id -u)"
+	if [ "$uid" != '0' ]; then
+		# if we're not root, we must be trying to run rootless
+		if ! command -v rootlesskit > /dev/null; then
+			echo >&2 "error: attempting to run rootless dockerd but missing 'rootlesskit' (perhaps the 'docker:dind-rootless' image variant is intended?)"
+			exit 1
+		fi
+		user="$(id -un 2>/dev/null || :)"
+		if ! grep -qE "^($uid${user:+|$user}):" /etc/subuid || ! grep -qE "^($uid${user:+|$user}):" /etc/subgid; then
+			echo >&2 "error: attempting to run rootless dockerd but missing necessary entries in /etc/subuid and/or /etc/subgid for $uid"
+			exit 1
+		fi
+		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
+		export XDG_RUNTIME_DIR
+		if ! mkdir -p "$XDG_RUNTIME_DIR" || [ ! -w "$XDG_RUNTIME_DIR" ] || ! mkdir -p "$HOME/.local/share/docker" || [ ! -w "$HOME/.local/share/docker" ]; then
+			echo >&2 "error: attempting to run rootless dockerd but need writable HOME ($HOME) and XDG_RUNTIME_DIR ($XDG_RUNTIME_DIR) for user $uid"
+			exit 1
+		fi
+		if [ -f /proc/sys/kernel/unprivileged_userns_clone ] && unprivClone="$(cat /proc/sys/kernel/unprivileged_userns_clone)" && [ "$unprivClone" != '1' ]; then
+			echo >&2 "error: attempting to run rootless dockerd but need 'kernel.unprivileged_userns_clone' (/proc/sys/kernel/unprivileged_userns_clone) set to 1"
+			exit 1
+		fi
+		if [ -f /proc/sys/user/max_user_namespaces ] && maxUserns="$(cat /proc/sys/user/max_user_namespaces)" && [ "$maxUserns" = '0' ]; then
+			echo >&2 "error: attempting to run rootless dockerd but need 'user.max_user_namespaces' (/proc/sys/user/max_user_namespaces) set to a sufficiently large value"
+			exit 1
+		fi
+		# TODO overlay support detection?
+		exec rootlesskit \
+			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+			--disable-host-loopback \
+			--port-driver=builtin \
+			--copy-up=/etc \
+			--copy-up=/run \
+			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+			"$@"
+	elif [ -x '/usr/local/bin/dind' ]; then
+		# if we have the (mostly defunct now) Docker-in-Docker wrapper script, use it
+		set -- '/usr/local/bin/dind' "$@"
+	fi
+else
+	# if it isn't `dockerd` we're trying to run, pass it through `docker-entrypoint.sh` so it gets `DOCKER_HOST` set appropriately too
+	set -- docker-entrypoint.sh "$@"
+fi
+
+exec "$@"

--- a/custom/air-gapped-kind/entrypoint-wrapper.sh
+++ b/custom/air-gapped-kind/entrypoint-wrapper.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-KIND_NODE_IMAGE=$1
-REGISTRY_IMAGE=$2
+KIND_NODE_IMAGE="kindest/node:v1.21.1"
+REGISTRY_IMAGE="registry:2"
 
 echo -e "[Info]: -----------------------Setting up KIND cluster-----------------------"
 

--- a/custom/air-gapped-kind/entrypoint-wrapper.sh
+++ b/custom/air-gapped-kind/entrypoint-wrapper.sh
@@ -16,7 +16,7 @@ while ! docker info; do
 done
 
 # Import pre-installed images
-for file in ./assets/*.tar; do
+for file in ./assets/*.tar.gz; do
   docker load -q <$file
 done
 

--- a/custom/air-gapped-kind/entrypoint-wrapper.sh
+++ b/custom/air-gapped-kind/entrypoint-wrapper.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+KIND_NODE_IMAGE=$1
+REGISTRY_IMAGE=$2
+
+echo -e "[Info]: -----------------------Setting up KIND cluster-----------------------"
+
+# Start docker service in background
+/usr/local/bin/dockerd-entrypoint.sh &
+
+# Wait that the docker service is up
+while ! docker info; do
+  echo "Waiting docker..."
+  sleep 3
+done
+
+# Import pre-installed images
+for file in ./assets/*.tar; do
+  docker load -q <$file
+done
+
+# create registry container unless it already exists
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
+    ${REGISTRY_IMAGE}
+fi
+
+# create a cluster with the local registry enabled in containerd
+kind create cluster --image ${KIND_NODE_IMAGE} --config=./kind-config.yml --wait=900s
+
+echo -e "[Info]: -----------------------Setting up Local Registry -----------------------"
+# connect the registry to the cluster network
+# (the network may already be connected)
+docker network connect "kind" "${reg_name}" || true
+
+# Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+
+local_registry="localhost:${reg_port}"
+
+echo -e "[Info]: -----------------------Local Registry created: ${local_registry} -----------------------"
+
+# Importing provided images into local registry
+echo -e "\n[Info]: --------------- Loading all provided images to local registry---------------\n"
+for file in ./registry/*.tar.gz; do
+  loaded=$(docker load -q <$file)
+  full_image_name=$(echo ${loaded:14})
+  array=(`echo $full_image_name | sed 's|/|\n|g'`)
+  image_with_tag=${array[-1]}
+  repo=${array[-2]}
+  docker tag ${repo}/${image_with_tag} ${local_registry}/${image_with_tag}
+  #Pushing the newly tagged image to local-registry & deleting the original image
+  docker push -q ${local_registry}/${image_with_tag} && docker image rm ${repo}/${image_with_tag}
+done
+
+exec "$@"

--- a/custom/air-gapped-kind/kind-config.yml
+++ b/custom/air-gapped-kind/kind-config.yml
@@ -1,0 +1,6 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+containerdConfigPatches:
+  - |
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+      endpoint = ["http://kind-registry:5000"]

--- a/custom/air-gapped-kind/modprobe.sh
+++ b/custom/air-gapped-kind/modprobe.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+# "modprobe" without modprobe
+# https://twitter.com/lucabruno/status/902934379835662336
+
+# this isn't 100% fool-proof, but it'll have a much higher success rate than simply using the "real" modprobe
+
+# Docker often uses "modprobe -va foo bar baz"
+# so we ignore modules that start with "-"
+for module; do
+	if [ "${module#-}" = "$module" ]; then
+		ip link show "$module" || true
+		lsmod | grep "$module" || true
+	fi
+done
+
+# remove /usr/local/... from PATH so we can exec the real modprobe as a last resort
+export PATH='/usr/sbin:/usr/bin:/sbin:/bin'
+exec modprobe "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**This PR will add a setup for air-gapped testing inside a docker container.**

Command for starting the container with no network - 
`docker run -t --rm --network none -v "$(pwd)"/registry:/air-gapped-kind/registry --privileged litmuschaos/air-gapped-kind:latest /bin/bash`

**As we have given the network as `none`, so there will be no access to outside internet.**

**The directory structure & Dockerfile have been made considering `dind` (Docker-in-Docker) image**. - https://github.com/docker-library/docker

**Some points about the setup-** 
- By default, A kind cluster & a local registry is already configured inside the host container.
- local-registry will be configured at `localhost:5000`, so images can be pulled from the same. 
- While testing, we can pull & save all required images in assets directory & mount the same inside the host container. The images which will be mounted in `registry` directory, will be automatically pushed to local registry inside the container (Configured on the entrypoint of container).

For e.g., if `litmuschaos/litmusportal-frontend:ci` is pulled & saved into registry directory & it has been mounted in the registry directory inside the host container. Then it will be automatically pushed to local registry. Inside the host container, the images can be pulled as `localhost:5000/litmusportal-frontend:ci` from local-registry.

Sample pipeline with Cypress tests & ChaosCenter running inside the host container can be found here - https://github.com/Jonsy13/e2e-test/actions/runs/1616378952

> In above pipeline, the tests are running inside a docker container. 
> The tests can also be run as a pod inside the kind cluster as well.
> The logic for running tests inside the host container can be decided by user.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Image for container reference -** 

![Screenshot from 2021-12-23 23-46-38](https://user-images.githubusercontent.com/40681425/147278190-e5809fcd-0b3b-40fb-bc88-b9fc44a00b2c.png)

