### PR TITLE
Updating base image of litmus-infra to alpine:3.15.0 due to some CVEs

### DIFF
--- a/custom/hardened-alpine/experiment/Dockerfile
+++ b/custom/hardened-alpine/experiment/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile contains the hardened alpine image with all the
 # litmus experiment dependencies installed.
 # It is also made non-root, sudo-enabled with default litmus directory.
-FROM alpine:3.14.2
+FROM alpine:3.15.0
 
 LABEL maintainer="LitmusChaos"
 

--- a/custom/hardened-alpine/infra/Dockerfile
+++ b/custom/hardened-alpine/infra/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile contains the hardened alpine image that can be used in litmus components.
 # It is also made non-root with default litmus directory.
-FROM alpine:3.14.2
+FROM alpine:3.15.0
 
 LABEL maintainer="LitmusChaos"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

CVEs list
```
Testing litmuschaos/infra-alpine...

✗ Medium severity vulnerability found in busybox/busybox
  Description: CVE-2021-42375
  Info: https://snyk.io/vuln/SNYK-ALPINE314-BUSYBOX-1915650
  Introduced through: busybox/busybox@1.33.1-r3, alpine-baselayout/alpine-baselayout@3.2.0-r16, bash/bash@5.1.4-r0, ca-certificates/ca-certificates@20191127-r5, busybox/ssl_client@1.33.1-r3
  From: busybox/busybox@1.33.1-r3
  From: alpine-baselayout/alpine-baselayout@3.2.0-r16 > busybox/busybox@1.33.1-r3
  From: bash/bash@5.1.4-r0 > busybox/busybox@1.33.1-r3
  and 2 more...
  Image layer: '-o pipefail -c apk add --no-cache ca-certificates'
  Fixed in: 1.33.1-r5

✗ Medium severity vulnerability found in busybox/busybox
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-ALPINE314-BUSYBOX-1915653
  Introduced through: busybox/busybox@1.33.1-r3, alpine-baselayout/alpine-baselayout@3.2.0-r16, bash/bash@5.1.4-r0, ca-certificates/ca-certificates@20191127-r5, busybox/ssl_client@1.33.1-r3
  From: busybox/busybox@1.33.1-r3
  From: alpine-baselayout/alpine-baselayout@3.2.0-r16 > busybox/busybox@1.33.1-r3
  From: bash/bash@5.1.4-r0 > busybox/busybox@1.33.1-r3
  and 2 more...
  Image layer: '-o pipefail -c apk add --no-cache ca-certificates'
  Fixed in: 1.33.1-r4

✗ High severity vulnerability found in busybox/busybox
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-ALPINE314-BUSYBOX-1920713
  Introduced through: busybox/busybox@1.33.1-r3, alpine-baselayout/alpine-baselayout@3.2.0-r16, bash/bash@5.1.4-r0, ca-certificates/ca-certificates@20191127-r5, busybox/ssl_client@1.33.1-r3
  From: busybox/busybox@1.33.1-r3
  From: alpine-baselayout/alpine-baselayout@3.2.0-r16 > busybox/busybox@1.33.1-r3
  From: bash/bash@5.1.4-r0 > busybox/busybox@1.33.1-r3
  and 2 more...
  Image layer: '-o pipefail -c apk add --no-cache ca-certificates'
  Fixed in: 1.33.1-r6

✗ High severity vulnerability found in busybox/busybox
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-ALPINE314-BUSYBOX-1920718
  Introduced through: busybox/busybox@1.33.1-r3, alpine-baselayout/alpine-baselayout@3.2.0-r16, bash/bash@5.1.4-r0, ca-certificates/ca-certificates@20191127-r5, busybox/ssl_client@1.33.1-r3
  From: busybox/busybox@1.33.1-r3
  From: alpine-baselayout/alpine-baselayout@3.2.0-r16 > busybox/busybox@1.33.1-r3
  From: bash/bash@5.1.4-r0 > busybox/busybox@1.33.1-r3
  and 2 more...
  Image layer: '-o pipefail -c apk add --no-cache ca-certificates'
  Fixed in: 1.33.1-r6

✗ High severity vulnerability found in busybox/busybox
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-ALPINE314-BUSYBOX-1920720
  Introduced through: busybox/busybox@1.33.1-r3, alpine-baselayout/alpine-baselayout@3.2.0-r16, bash/bash@5.1.4-r0, ca-certificates/ca-certificates@20191127-r5, busybox/ssl_client@1.33.1-r3
  From: busybox/busybox@1.33.1-r3
  From: alpine-baselayout/alpine-baselayout@3.2.0-r16 > busybox/busybox@1.33.1-r3
  From: bash/bash@5.1.4-r0 > busybox/busybox@1.33.1-r3
  and 2 more...
  Image layer: '-o pipefail -c apk add --no-cache ca-certificates'
  Fixed in: 1.33.1-r6

✗ High severity vulnerability found in busybox/busybox
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-ALPINE314-BUSYBOX-1920722
  Introduced through: busybox/busybox@1.33.1-r3, alpine-baselayout/alpine-baselayout@3.2.0-r16, bash/bash@5.1.4-r0, ca-certificates/ca-certificates@20191127-r5, busybox/ssl_client@1.33.1-r3
  From: busybox/busybox@1.33.1-r3
  From: alpine-baselayout/alpine-baselayout@3.2.0-r16 > busybox/busybox@1.33.1-r3
  From: bash/bash@5.1.4-r0 > busybox/busybox@1.33.1-r3
  and 2 more...
  Image layer: '-o pipefail -c apk add --no-cache ca-certificates'
  Fixed in: 1.33.1-r6

✗ High severity vulnerability found in busybox/busybox
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-ALPINE314-BUSYBOX-1920733
  Introduced through: busybox/busybox@1.33.1-r3, alpine-baselayout/alpine-baselayout@3.2.0-r16, bash/bash@5.1.4-r0, ca-certificates/ca-certificates@20191127-r5, busybox/ssl_client@1.33.1-r3
  From: busybox/busybox@1.33.1-r3
  From: alpine-baselayout/alpine-baselayout@3.2.0-r16 > busybox/busybox@1.33.1-r3
  From: bash/bash@5.1.4-r0 > busybox/busybox@1.33.1-r3
  and 2 more...
  Image layer: '-o pipefail -c apk add --no-cache ca-certificates'
  Fixed in: 1.33.1-r6

✗ High severity vulnerability found in busybox/busybox
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-ALPINE314-BUSYBOX-1920734
  Introduced through: busybox/busybox@1.33.1-r3, alpine-baselayout/alpine-baselayout@3.2.0-r16, bash/bash@5.1.4-r0, ca-certificates/ca-certificates@20191127-r5, busybox/ssl_client@1.33.1-r3
  From: busybox/busybox@1.33.1-r3
  From: alpine-baselayout/alpine-baselayout@3.2.0-r16 > busybox/busybox@1.33.1-r3
  From: bash/bash@5.1.4-r0 > busybox/busybox@1.33.1-r3
  and 2 more...
  Image layer: '-o pipefail -c apk add --no-cache ca-certificates'
  Fixed in: 1.33.1-r6

✗ High severity vulnerability found in busybox/busybox
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-ALPINE314-BUSYBOX-1920744
  Introduced through: busybox/busybox@1.33.1-r3, alpine-baselayout/alpine-baselayout@3.2.0-r16, bash/bash@5.1.4-r0, ca-certificates/ca-certificates@20191127-r5, busybox/ssl_client@1.33.1-r3
  From: busybox/busybox@1.33.1-r3
  From: alpine-baselayout/alpine-baselayout@3.2.0-r16 > busybox/busybox@1.33.1-r3
  From: bash/bash@5.1.4-r0 > busybox/busybox@1.33.1-r3
  and 2 more...
  Image layer: '-o pipefail -c apk add --no-cache ca-certificates'
  Fixed in: 1.33.1-r6

✗ High severity vulnerability found in busybox/busybox
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-ALPINE314-BUSYBOX-1920745
  Introduced through: busybox/busybox@1.33.1-r3, alpine-baselayout/alpine-baselayout@3.2.0-r16, bash/bash@5.1.4-r0, ca-certificates/ca-certificates@20191127-r5, busybox/ssl_client@1.33.1-r3
  From: busybox/busybox@1.33.1-r3
  From: alpine-baselayout/alpine-baselayout@3.2.0-r16 > busybox/busybox@1.33.1-r3
  From: bash/bash@5.1.4-r0 > busybox/busybox@1.33.1-r3
  and 2 more...
  Image layer: '-o pipefail -c apk add --no-cache ca-certificates'
  Fixed in: 1.33.1-r6

✗ High severity vulnerability found in busybox/busybox
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-ALPINE314-BUSYBOX-1920755
  Introduced through: busybox/busybox@1.33.1-r3, alpine-baselayout/alpine-baselayout@3.2.0-r16, bash/bash@5.1.4-r0, ca-certificates/ca-certificates@20191127-r5, busybox/ssl_client@1.33.1-r3
  From: busybox/busybox@1.33.1-r3
  From: alpine-baselayout/alpine-baselayout@3.2.0-r16 > busybox/busybox@1.33.1-r3
  From: bash/bash@5.1.4-r0 > busybox/busybox@1.33.1-r3
  and 2 more...
  Image layer: '-o pipefail -c apk add --no-cache ca-certificates'
  Fixed in: 1.33.1-r6



Package manager:   apk
Project name:      docker-image|litmuschaos/infra-alpine
Docker image:      litmuschaos/infra-alpine
Platform:          linux/amd64
Base image:        alpine:3.14.2

Tested 24 dependencies for known vulnerabilities, found 11 vulnerabilities.

Base Image     Vulnerabilities  Severity
alpine:3.14.2  11               0 critical, 9 high, 2 medium, 0 low

Recommendations for base image upgrade:

Minor upgrades
Base Image   Vulnerabilities  Severity
alpine:3.14  0                0 critical, 0 high, 0 medium, 0 low


For more free scans that keep your images secure, sign up to Snyk at https://dockr.ly/3ePqVcp

```