### PR TITLE
Upgrading alpine image version to 3.16 for reducing vulnerabilities

### DIFF
--- a/custom/hardened-alpine/experiment/Dockerfile
+++ b/custom/hardened-alpine/experiment/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile contains the hardened alpine image with all the
 # litmus experiment dependencies installed.
 # It is also made non-root, sudo-enabled with default litmus directory.
-FROM alpine:3.15.0
+FROM alpine:3.16.0
 
 LABEL maintainer="LitmusChaos"
 

--- a/custom/hardened-alpine/experiment/Dockerfile
+++ b/custom/hardened-alpine/experiment/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile contains the hardened alpine image with all the
 # litmus experiment dependencies installed.
 # It is also made non-root, sudo-enabled with default litmus directory.
-FROM alpine:3.16.0
+FROM alpine:3.16.2
 
 LABEL maintainer="LitmusChaos"
 

--- a/custom/hardened-alpine/infra/Dockerfile
+++ b/custom/hardened-alpine/infra/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile contains the hardened alpine image that can be used in litmus components.
 # It is also made non-root with default litmus directory.
-FROM alpine:3.16.0
+FROM alpine:3.16.2
 
 LABEL maintainer="LitmusChaos"
 

--- a/custom/hardened-alpine/infra/Dockerfile
+++ b/custom/hardened-alpine/infra/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile contains the hardened alpine image that can be used in litmus components.
 # It is also made non-root with default litmus directory.
-FROM alpine:3.15.0
+FROM alpine:3.16.0
 
 LABEL maintainer="LitmusChaos"
 


### PR DESCRIPTION
Signed-off-by: Jonsy13 <vedant.shrotria@harness.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Before -** 

```
✗ Low severity vulnerability found in curl/libcurl
  Description: CVE-2022-32221
  Info: https://snyk.io/vuln/SNYK-ALPINE315-CURL-3063708
  Introduced through: curl/libcurl@7.80.0-r3, curl/curl@7.80.0-r3
  From: curl/libcurl@7.80.0-r3
  From: curl/curl@7.80.0-r3 > curl/libcurl@7.80.0-r3
  From: curl/curl@7.80.0-r3
  Fixed in: 7.80.0-r4

✗ Low severity vulnerability found in curl/libcurl
  Description: CVE-2022-42916
  Info: https://snyk.io/vuln/SNYK-ALPINE315-CURL-3063709
  Introduced through: curl/libcurl@7.80.0-r3, curl/curl@7.80.0-r3
  From: curl/libcurl@7.80.0-r3
  From: curl/curl@7.80.0-r3 > curl/libcurl@7.80.0-r3
  From: curl/curl@7.80.0-r3
  Fixed in: 7.80.0-r4

✗ Low severity vulnerability found in curl/libcurl
  Description: CVE-2022-42915
  Info: https://snyk.io/vuln/SNYK-ALPINE315-CURL-3063710
  Introduced through: curl/libcurl@7.80.0-r3, curl/curl@7.80.0-r3
  From: curl/libcurl@7.80.0-r3
  From: curl/curl@7.80.0-r3 > curl/libcurl@7.80.0-r3
  From: curl/curl@7.80.0-r3
  Fixed in: 7.80.0-r4

✗ Low severity vulnerability found in busybox/busybox
  Description: ALPINE-13661
  Info: https://snyk.io/vuln/SNYK-ALPINE315-BUSYBOX-2606932
  Introduced through: busybox/busybox@1.34.1-r3, alpine-baselayout/alpine-baselayout@3.2.0-r18, bash/bash@5.1.16-r0, ca-certificates/ca-certificates@20220614-r0, busybox/ssl_client@1.34.1-r3
  From: busybox/busybox@1.34.1-r3
  From: alpine-baselayout/alpine-baselayout@3.2.0-r18 > busybox/busybox@1.34.1-r3
  From: bash/bash@5.1.16-r0 > busybox/busybox@1.34.1-r3
  and 2 more...
  Fixed in: 1.34.1-r5

✗ Medium severity vulnerability found in openssl/libcrypto1.1
  Description: Inadequate Encryption Strength
  Info: https://snyk.io/vuln/SNYK-ALPINE315-OPENSSL-2941810
  Introduced through: openssl/libcrypto1.1@1.1.1l-r7, openssl/libssl1.1@1.1.1l-r7, apk-tools/apk-tools@2.12.7-r3, libretls/libretls@3.3.4-r2, ca-certificates/ca-certificates@20220614-r0, curl/libcurl@7.80.0-r3
  From: openssl/libcrypto1.1@1.1.1l-r7
  From: openssl/libssl1.1@1.1.1l-r7 > openssl/libcrypto1.1@1.1.1l-r7
  From: apk-tools/apk-tools@2.12.7-r3 > openssl/libcrypto1.1@1.1.1l-r7
  and 7 more...
  Fixed in: 1.1.1q-r0

✗ High severity vulnerability found in zlib/zlib
  Description: Out-of-bounds Write
  Info: https://snyk.io/vuln/SNYK-ALPINE315-ZLIB-2434420
  Introduced through: zlib/zlib@1.2.11-r3, apk-tools/apk-tools@2.12.7-r3, curl/libcurl@7.80.0-r3, curl/curl@7.80.0-r3, sudo/sudo@1.9.8_p2-r1
  From: zlib/zlib@1.2.11-r3
  From: apk-tools/apk-tools@2.12.7-r3 > zlib/zlib@1.2.11-r3
  From: curl/libcurl@7.80.0-r3 > zlib/zlib@1.2.11-r3
  and 2 more...
  Fixed in: 1.2.12-r0

✗ High severity vulnerability found in openssl/libcrypto1.1
  Description: Loop with Unreachable Exit Condition ('Infinite Loop')
  Info: https://snyk.io/vuln/SNYK-ALPINE315-OPENSSL-2426331
  Introduced through: openssl/libcrypto1.1@1.1.1l-r7, openssl/libssl1.1@1.1.1l-r7, apk-tools/apk-tools@2.12.7-r3, libretls/libretls@3.3.4-r2, ca-certificates/ca-certificates@20220614-r0, curl/libcurl@7.80.0-r3
  From: openssl/libcrypto1.1@1.1.1l-r7
  From: openssl/libssl1.1@1.1.1l-r7 > openssl/libcrypto1.1@1.1.1l-r7
  From: apk-tools/apk-tools@2.12.7-r3 > openssl/libcrypto1.1@1.1.1l-r7
  and 7 more...
  Fixed in: 1.1.1n-r0

✗ High severity vulnerability found in libretls/libretls
  Description: Loop with Unreachable Exit Condition ('Infinite Loop')
  Info: https://snyk.io/vuln/SNYK-ALPINE315-LIBRETLS-2428776
  Introduced through: libretls/libretls@3.3.4-r2, busybox/ssl_client@1.34.1-r3
  From: libretls/libretls@3.3.4-r2
  From: busybox/ssl_client@1.34.1-r3 > libretls/libretls@3.3.4-r2
  Fixed in: 3.3.4-r3

✗ High severity vulnerability found in busybox/busybox
  Description: CVE-2022-28391
  Info: https://snyk.io/vuln/SNYK-ALPINE315-BUSYBOX-2440607
  Introduced through: busybox/busybox@1.34.1-r3, alpine-baselayout/alpine-baselayout@3.2.0-r18, bash/bash@5.1.16-r0, ca-certificates/ca-certificates@20220614-r0, busybox/ssl_client@1.34.1-r3
  From: busybox/busybox@1.34.1-r3
  From: alpine-baselayout/alpine-baselayout@3.2.0-r18 > busybox/busybox@1.34.1-r3
  From: bash/bash@5.1.16-r0 > busybox/busybox@1.34.1-r3
  and 2 more...
  Fixed in: 1.34.1-r5

✗ Critical severity vulnerability found in zlib/zlib
  Description: Out-of-bounds Write
  Info: https://snyk.io/vuln/SNYK-ALPINE315-ZLIB-2976173
  Introduced through: zlib/zlib@1.2.11-r3, apk-tools/apk-tools@2.12.7-r3, curl/libcurl@7.80.0-r3, curl/curl@7.80.0-r3, sudo/sudo@1.9.8_p2-r1
  From: zlib/zlib@1.2.11-r3
  From: apk-tools/apk-tools@2.12.7-r3 > zlib/zlib@1.2.11-r3
  From: curl/libcurl@7.80.0-r3 > zlib/zlib@1.2.11-r3
  and 2 more...
  Fixed in: 1.2.12-r2
```

**After -** 

```
~/go/src/github.com/harness/hce-saas/graphql/server fix/update-csv *25 !14 ❯ docker scan  docker.io/amitkrdas/saas-```
gql:latest                                                                                    47s 02:04:11 PM

Testing docker.io/amitkrdas/saas-gql:latest...

Package manager:   apk
Project name:      docker-image|docker.io/amitkrdas/saas-gql
Docker image:      docker.io/amitkrdas/saas-gql:latest
Platform:          linux/arm64

✔ Tested 14 dependencies for known vulnerabilities, no vulnerable paths found.

For more free scans that keep your images secure, sign up to Snyk at https://dockr.ly/3ePqVcp
```

**Special notes for your reviewer**:
