### PR TITLE
Added support for SKIP_SSL env in litmus-helm-agent

### DIFF
--- a/custom/litmus-helm-agent/main.go
+++ b/custom/litmus-helm-agent/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	litmus "litmus-helm-agent/pkg/litmus"
+	"net/http"
 	"os"
 )
 
@@ -17,6 +19,11 @@ var (
 func init() {
 	flag.StringVar(&ACTION, "action", "", "create|delete litmus agent")
 	flag.Parse()
+
+	// For all litmus-helm-agent to ChaosCenter communications, This will apply to all requests.
+	if os.Getenv("SKIP_SSL") == "true" {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 
 	LITMUS_FRONTEND_URL = os.Getenv("LITMUS_FRONTEND_URL")
 	LITMUS_USERNAME = os.Getenv("LITMUS_USERNAME")

--- a/custom/litmus-helm-agent/pkg/litmus/client.go
+++ b/custom/litmus-helm-agent/pkg/litmus/client.go
@@ -25,7 +25,7 @@ func prepareNewAgent() types.Agent {
 	newAgent.Description = os.Getenv("AGENT_DESCRIPTION")
 	newAgent.ProjectId = os.Getenv("LITMUS_PROJECT_ID")
 	newAgent.Mode = os.Getenv("AGENT_MODE")
-	newAgent.SkipSSL = true
+	newAgent.SkipSSL, _ = strconv.ParseBool(os.Getenv("SKIP_SSL"))
 
 	// -- OPTIONAL -- //
 	newAgent.ClusterType = os.Getenv("CLUSTER_TYPE")
@@ -46,7 +46,7 @@ func prepareAgentConfigMap() map[string]string {
 	selector := `["litmuschaos.io/app=chaos-exporter", "litmuschaos.io/app=chaos-operator", "litmuschaos.io/app=event-tracker", "litmuschaos.io/app=workflow-controller"]`
 	configMapData["COMPONENTS"] = "DEPLOYMENTS: " + selector
 	configMapData["AGENT_SCOPE"] = os.Getenv("AGENT_MODE")
-	configMapData["SKIP_SSL_VERIFY"] = "true"
+	configMapData["SKIP_SSL_VERIFY"] = os.Getenv("SKIP_SSL")
 	return configMapData
 }
 


### PR DESCRIPTION
Signed-off-by: Jonsy13 <vedant.shrotria@harness.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR will add support for skipping SSL verification 
- when communicating between `litmus-helm-agent` & `ChaosCenter`
- sets `SKIP_SSL_VERIFY`env accordingly for `subscriber` <-> `chaoscenter`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
