### PR TITLE
Update Mongo Image to version 6

### DIFF
--- a/custom/mongo/Dockerfile
+++ b/custom/mongo/Dockerfile
@@ -1,2 +1,2 @@
-FROM mongo:4.2.8
+FROM mongo:6
 ARG TARGETPLATFORM

--- a/custom/mongo/buildscripts/push
+++ b/custom/mongo/buildscripts/push
@@ -5,7 +5,7 @@ if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
 then
   docker login -u "${DNAME}" -p "${DPASS}";
   #Push to docker hub repository with latest tag
-  docker buildx build . -f Dockerfile --progress plain --push --no-cache --platform linux/amd64,linux/arm64 --tag litmuschaos/mongo:4.2.8
+  docker buildx build . -f Dockerfile --progress plain --push --no-cache --platform linux/amd64,linux/arm64 --tag litmuschaos/mongo:6
 else
-  echo "No docker credentials provided. Skip uploading litmuschaos/mongo:4.2.8 to docker hub";
+  echo "No docker credentials provided. Skip uploading litmuschaos/mongo:6 to docker hub";
 fi;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Update Mongo Image to version 6 - This is required because we need mongosh tool in 3.0.0 ChaosCenter wait init-container.**

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
