### PR TITLE
Bumped Alpine version from 3.16.2 to 3.16.9 to fix vulnerabilities

### DIFF
--- a/custom/hardened-alpine/experiment/Dockerfile
+++ b/custom/hardened-alpine/experiment/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile contains the hardened alpine image with all the
 # litmus experiment dependencies installed.
 # It is also made non-root, sudo-enabled with default litmus directory.
-FROM alpine:3.16.2
+FROM alpine:3.16.9
 
 LABEL maintainer="LitmusChaos"
 

--- a/custom/hardened-alpine/experiment/Dockerfile
+++ b/custom/hardened-alpine/experiment/Dockerfile
@@ -40,6 +40,7 @@ RUN set -ex && \
          do curl -sSL ${GLIBC_REPO}/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
      apk add --allow-untrusted --force overwrite /tmp/*.apk && \
      rm -v /tmp/*.apk && \
+     ln -sf /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib && \
      /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib
 
 # Change default shell from ash to bash

--- a/custom/hardened-alpine/experiment/Dockerfile
+++ b/custom/hardened-alpine/experiment/Dockerfile
@@ -40,7 +40,6 @@ RUN set -ex && \
          do curl -sSL ${GLIBC_REPO}/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
      apk add --allow-untrusted --force-overwrite /tmp/*.apk && \
      rm -v /tmp/*.apk && \
-     ln -sf /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib && \
      /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib
 
 # Change default shell from ash to bash

--- a/custom/hardened-alpine/experiment/Dockerfile
+++ b/custom/hardened-alpine/experiment/Dockerfile
@@ -38,7 +38,7 @@ RUN set -ex && \
      apk --update add libstdc++ curl ca-certificates && \
      for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION}; \
          do curl -sSL ${GLIBC_REPO}/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
-     apk add --allow-untrusted /tmp/*.apk && \
+     apk add --allow-untrusted --force overwrite /tmp/*.apk && \
      rm -v /tmp/*.apk && \
      /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib
 

--- a/custom/hardened-alpine/experiment/Dockerfile
+++ b/custom/hardened-alpine/experiment/Dockerfile
@@ -38,7 +38,7 @@ RUN set -ex && \
      apk --update add libstdc++ curl ca-certificates && \
      for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION}; \
          do curl -sSL ${GLIBC_REPO}/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
-     apk add --allow-untrusted --force overwrite /tmp/*.apk && \
+     apk add --allow-untrusted --force-overwrite /tmp/*.apk && \
      rm -v /tmp/*.apk && \
      ln -sf /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib && \
      /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Fix the High Severity vulnerabilities found in Alpine 3.16.2:

https://nvd.nist.gov/vuln/detail/CVE-2023-0215
https://nvd.nist.gov/vuln/detail/CVE-2022-4450
https://nvd.nist.gov/vuln/detail/CVE-2023-0286 

**Which issue this PR fixes**: fixes #524 

**Special notes for your reviewer**: N/A

**Checklist:**
-   [x] Fixes #524 
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes