### PR TITLE
Revert "Bumped Alpine version from 3.16.2 to 3.16.9 to fix vulnerabilities 

### DIFF
--- a/custom/hardened-alpine/experiment/Dockerfile
+++ b/custom/hardened-alpine/experiment/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile contains the hardened alpine image with all the
 # litmus experiment dependencies installed.
 # It is also made non-root, sudo-enabled with default litmus directory.
-FROM alpine:3.16.9
+FROM alpine:3.16.2
 
 LABEL maintainer="LitmusChaos"
 
@@ -38,7 +38,7 @@ RUN set -ex && \
      apk --update add libstdc++ curl ca-certificates && \
      for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION}; \
          do curl -sSL ${GLIBC_REPO}/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
-     apk add --allow-untrusted --force-overwrite /tmp/*.apk && \
+     apk add --allow-untrusted /tmp/*.apk && \
      rm -v /tmp/*.apk && \
      /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib
 


### PR DESCRIPTION


This reverts commit 51597bca9c4f866532b5a3e1a95f3b14a5b64b0e.

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
