### PR TITLE
Update workflow configmap model

### DIFF
--- a/custom/litmus-helm-agent/pkg/litmus/client.go
+++ b/custom/litmus-helm-agent/pkg/litmus/client.go
@@ -148,13 +148,13 @@ func CreateInfra(credentials types.Credentials) {
 
 		clientset := kubernetes.ConnectKubeApi()
 		configMap := prepareInfraConfigMap()
-		kubernetes.CreateConfigMap(os.Getenv("INFRA_CONFIGMAP_NAME"), configMap, os.Getenv("NAMESPACE"), clientset)
+		kubernetes.PatchConfigMap(os.Getenv("INFRA_CONFIGMAP_NAME"), configMap, os.Getenv("NAMESPACE"), clientset)
 
 		secret := prepareInfraSecret(connectionData.Data, accessKey)
 		kubernetes.CreateSecret(os.Getenv("INFRA_SECRET_NAME"), secret, os.Getenv("NAMESPACE"), clientset)
 
 		workflowConfigMap := prepareWorkflowControllerConfigMap(connectionData.Data.RegisterInfraDetails.InfraID)
-		kubernetes.CreateConfigMap(os.Getenv("WORKFLOW_CONTROLER_CONFIGMAP_NAME"), workflowConfigMap, os.Getenv("NAMESPACE"), clientset)
+		kubernetes.PatchConfigMap(os.Getenv("WORKFLOW_CONTROLER_CONFIGMAP_NAME"), workflowConfigMap, os.Getenv("NAMESPACE"), clientset)
 
 		fmt.Printf("Infra Successfully declared, starting...\n")
 	} else {

--- a/custom/litmus-helm-agent/pkg/litmus/client.go
+++ b/custom/litmus-helm-agent/pkg/litmus/client.go
@@ -65,12 +65,12 @@ func prepareInfraSecret(infraConnect infrastructure.RegisterInfra, accessKey str
 
 func prepareWorkflowControllerConfigMap(clusterID string) map[string]string {
 	configMapWorkflowController := make(map[string]string)
-	configMapWorkflowController["config"] = (`    containerRuntimeExecutor: ` + os.Getenv("CONTAINER_RUNTIME_EXECUTOR") + `
-    executor:
-      imagePullPolicy: IfNotPresent
-    instanceID: ` + clusterID)
-	return configMapWorkflowController
 
+	configMapWorkflowController["containerRuntimeExecutor"] = os.Getenv("CONTAINER_RUNTIME_EXECUTOR")
+	configMapWorkflowController["instanceID"] = clusterID
+	configMapWorkflowController["executor"] = "imagePullPolicy: IfNotPresent\n"
+
+	return configMapWorkflowController
 }
 
 func GetProjectID(credentials types.Credentials) string {

--- a/custom/litmus-helm-agent/pkg/litmus/client.go
+++ b/custom/litmus-helm-agent/pkg/litmus/client.go
@@ -68,7 +68,6 @@ func prepareWorkflowControllerConfigMap(clusterID string) map[string]string {
 
 	configMapWorkflowController["containerRuntimeExecutor"] = os.Getenv("CONTAINER_RUNTIME_EXECUTOR")
 	configMapWorkflowController["instanceID"] = clusterID
-	configMapWorkflowController["executor"] = "imagePullPolicy: IfNotPresent\n"
 
 	return configMapWorkflowController
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
https://github.com/litmuschaos/litmus-helm/issues/405
This PR update the litmus-helm-agent so instead of updating the workflow-controller-configmap it will patch it.
This is will allow to pass custom workflow-controlelr-configmap and so it's not overwrittent by the litmus-helm-agent.

**Special notes for your reviewer**:
At the moment, one configuration was removed from the helm-agent (the executor.imagePullPolicy) that will be added directly from the helm configuration to allow custom configuration in the "executor" section.