### PR TITLE
Builds multiarch binary for dns_interceptor during releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           cp custom/promql-cli/promql-linux-arm64 build/_output/
 
       - name: Build go binary for dns_interceptor
-        run : go build -o ./../../build/_output/dns_interceptor
+        run : ./../../build/go-multiarch-build.sh "go build -o ./../../build/_output/dns_interceptor"
         working-directory: custom/dns_interceptor
 
       - name: create release along with artifact


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Enables multi-architecture builds for "dns_interceptor" binary to support ARM64 based chaos. Earlier it only built for AMD64.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #697 

**Special notes for your reviewer**:
