### PR TITLE
fix: adds Kube API QPS and Burst as arguments and single API discovery

### DIFF
--- a/custom/litmus-checker/main.go
+++ b/custom/litmus-checker/main.go
@@ -23,6 +23,8 @@ func main() {
 	kubeconfig := flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	file := flag.String("file", "", "absolute path to the chaosengine yaml")
 	engineFile := flag.String("saveName", "", "absolute path to the output file")
+	qps := flag.Float64("qps", 5, "QPS for the Kubernetes client")
+	burst := flag.Int("burst", 10, "Burst for the Kubernetes client")
 	flag.Parse()
 
 	if file == nil || *file == "" {
@@ -34,7 +36,7 @@ func main() {
 		logrus.Fatalf("Error Reading Artefact : %v", err)
 	}
 
-	dc, dyn, err := k8s.GetDynamicClient(kubeconfig)
+	dc, dyn, err := k8s.GetDynamicClient(kubeconfig, *qps, *burst)
 	if err != nil {
 		logrus.Fatalf("Error Getting Dynamic Client : %v", err)
 	}

--- a/custom/litmus-checker/pkg/k8s/client.go
+++ b/custom/litmus-checker/pkg/k8s/client.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,9 +29,21 @@ type ResourceDef struct {
 
 var decUnstructured = yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 
+var (
+	globalMapper *restmapper.DeferredDiscoveryRESTMapper
+	mapperOnce   sync.Once
+)
+
+func getMapper(dc discovery.DiscoveryInterface) *restmapper.DeferredDiscoveryRESTMapper {
+	mapperOnce.Do(func() {
+		globalMapper = restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
+	})
+	return globalMapper
+}
+
 func CreateChaosDeployment(manifest []byte, dc discovery.DiscoveryInterface, dyn dynamic.Interface) (*unstructured.Unstructured, error) {
 
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
+	mapper := getMapper(dc)
 	// Decode YAML manifest into unstructured.Unstructured
 	obj := &unstructured.Unstructured{}
 	_, gvk, err := decUnstructured.Decode(manifest, nil, obj)
@@ -61,7 +74,7 @@ func CreateChaosDeployment(manifest []byte, dc discovery.DiscoveryInterface, dyn
 }
 
 func GetResourceDetails(dc discovery.DiscoveryInterface, dyn dynamic.Interface, res ResourceDef) (*unstructured.Unstructured, error) {
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
+	mapper := getMapper(dc)
 	// Find GVR
 	mapping, err := mapper.RESTMapping(schema.GroupKind{Group: res.Group, Kind: res.Kind}, res.Version)
 	if err != nil {
@@ -91,8 +104,10 @@ func GetKubeConfig(kubeconfig *string) (*rest.Config, error) {
 	return config, err
 }
 
-func GetDynamicClient(kubeconfig *string) (discovery.DiscoveryInterface, dynamic.Interface, error) {
+func GetDynamicClient(kubeconfig *string, qps float64, burst int) (discovery.DiscoveryInterface, dynamic.Interface, error) {
 	cfg, err := GetKubeConfig(kubeconfig)
+	cfg.QPS = float32(qps)
+	cfg.Burst = burst
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**: This PR solves #720 by configuring Kube API client QPS(default 5) and burst(default 10) as command line arguments for litmus-checker. It creates a reusable API discovery mapper to limit calls sent to Kubernetes API server.

Fixes #720

**Special notes for your reviewer**: Tested by building custom image and using on multiple experiments.
